### PR TITLE
feat(interface) ThreadSafeDatastoreCloser

### DIFF
--- a/datastore.go
+++ b/datastore.go
@@ -2,6 +2,7 @@ package datastore
 
 import (
 	"errors"
+	"io"
 )
 
 /*
@@ -61,6 +62,13 @@ type Datastore interface {
 type ThreadSafeDatastore interface {
 	Datastore
 	IsThreadSafe()
+}
+
+// ThreadSafeDatastoreCloser extends the ThreadSafeDatastore with the io.Closer
+// interface
+type ThreadSafeDatastoreCloser interface {
+	ThreadSafeDatastore
+	io.Closer
 }
 
 // Errors

--- a/leveldb/datastore.go
+++ b/leveldb/datastore.go
@@ -13,7 +13,7 @@ type Datastore struct {
 
 type Options opt.Options
 
-func NewDatastore(path string, opts *Options) (ds.ThreadSafeDatastore, error) {
+func NewDatastore(path string, opts *Options) (ds.ThreadSafeDatastoreCloser, error) {
 	var nopts opt.Options
 	if opts != nil {
 		nopts = opt.Options(*opts)

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -16,7 +16,7 @@ type MutexDatastore struct {
 
 // MutexWrap constructs a datastore with a coarse lock around
 // the entire datastore, for every single operation
-func MutexWrap(d ds.Datastore) ds.ThreadSafeDatastore {
+func MutexWrap(d ds.Datastore) ds.ThreadSafeDatastoreCloser {
 	return &MutexDatastore{child: d}
 }
 
@@ -62,3 +62,5 @@ func (d *MutexDatastore) KeyList() ([]ds.Key, error) {
 	defer d.RUnlock()
 	return d.child.KeyList()
 }
+
+func (d *MutexDatastore) Close() error { return nil } // no-op


### PR DESCRIPTION
Expose `Close()` to make it possible to clean up LevelDB instances.

License: MIT
Signed-off-by: Brian Tiger Chow brian@perfmode.com
