### PR TITLE
Backport from go-ipfs, fix tests, hopefully fix Windows

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -19,6 +19,10 @@
 			"Rev": "4dfff096c4973178c8f35cf6dd1a732a0a139370"
 		},
 		{
+			"ImportPath": "github.com/jbenet/go-os-rename",
+			"Rev": "2d93ae970ba96c41f717036a5bf5494faf1f38c0"
+		},
+		{
 			"ImportPath": "github.com/jbenet/goprocess",
 			"Rev": "5b02f8d275a2dd882fb06f8bbdf74347795ff3b1"
 		},

--- a/Godeps/_workspace/src/github.com/jbenet/go-os-rename/.travis.yml
+++ b/Godeps/_workspace/src/github.com/jbenet/go-os-rename/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+
+go:
+  - 1.4
+  - release
+
+script:
+  - go test -race -cpu=5 -v ./...

--- a/Godeps/_workspace/src/github.com/jbenet/go-os-rename/LICENSE
+++ b/Godeps/_workspace/src/github.com/jbenet/go-os-rename/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Godeps/_workspace/src/github.com/jbenet/go-os-rename/README.md
+++ b/Godeps/_workspace/src/github.com/jbenet/go-os-rename/README.md
@@ -1,0 +1,13 @@
+# go-os-rename
+
+Easily rename files in place. This is needed because Windows errors on rename if a file already exists. Please see this commit, from which the code is extracted: https://github.com/lvarvel/cacheddownloader/commit/505a1fd
+
+#### Godoc: https://godoc.org/github.com/jbenet/go-os-rename
+
+## Author
+
+The original author of this code are "David Morhovich, David Varvel and John Shahid" (see [this commit](https://github.com/lvarvel/cacheddownloader/commit/505a1fdcc5af7823f20d7c87d9e4d1c833c59053))
+
+## License
+
+The code originally comes from https://github.com/lvarvel/cacheddownloader, which is licensed Apache 2.0.

--- a/Godeps/_workspace/src/github.com/jbenet/go-os-rename/rename_std.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-os-rename/rename_std.go
@@ -1,0 +1,9 @@
+// +build !windows
+
+package osrename
+
+import "os"
+
+func Rename(src, dst string) error {
+	return os.Rename(src, dst)
+}

--- a/Godeps/_workspace/src/github.com/jbenet/go-os-rename/rename_windows.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-os-rename/rename_windows.go
@@ -1,0 +1,43 @@
+// +build windows
+
+package osrename
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+func Rename(src, dst string) error {
+	kernel32, err := syscall.LoadLibrary("kernel32.dll")
+	if err != nil {
+		return err
+	}
+	defer syscall.FreeLibrary(kernel32)
+	moveFileExUnicode, err := syscall.GetProcAddress(kernel32, "MoveFileExW")
+	if err != nil {
+		return err
+	}
+
+	srcString, err := syscall.UTF16PtrFromString(src)
+	if err != nil {
+		return err
+	}
+
+	dstString, err := syscall.UTF16PtrFromString(dst)
+	if err != nil {
+		return err
+	}
+
+	srcPtr := uintptr(unsafe.Pointer(srcString))
+	dstPtr := uintptr(unsafe.Pointer(dstString))
+
+	MOVEFILE_REPLACE_EXISTING := 0x1
+	flag := uintptr(MOVEFILE_REPLACE_EXISTING)
+
+	_, _, callErr := syscall.Syscall(uintptr(moveFileExUnicode), 3, srcPtr, dstPtr, flag)
+	if callErr != 0 {
+		return callErr
+	}
+
+	return nil
+}

--- a/flatfs/flatfs.go
+++ b/flatfs/flatfs.go
@@ -79,12 +79,7 @@ func (fs *Datastore) makePrefixDir(dir string) error {
 	// it, the creation of the prefix dir itself might not be
 	// durable yet. Sync the root dir after a successful mkdir of
 	// a prefix dir, just to be paranoid.
-	f, err := os.Open(fs.path)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	if err := f.Sync(); err != nil {
+	if err := syncDir(fs.path); err != nil {
 		return err
 	}
 	return nil
@@ -100,12 +95,6 @@ func (fs *Datastore) Put(key datastore.Key, value interface{}) error {
 	if err := fs.makePrefixDir(dir); err != nil {
 		return err
 	}
-
-	dirF, err := os.Open(dir)
-	if err != nil {
-		return err
-	}
-	defer dirF.Close()
 
 	tmp, err := ioutil.TempFile(dir, "put-")
 	if err != nil {
@@ -141,10 +130,9 @@ func (fs *Datastore) Put(key datastore.Key, value interface{}) error {
 	}
 	removed = true
 
-	if err := dirF.Sync(); err != nil {
+	if err := syncDir(dir); err != nil {
 		return err
 	}
-
 	return nil
 }
 

--- a/flatfs/flatfs.go
+++ b/flatfs/flatfs.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/jbenet/go-datastore"
+	"github.com/jbenet/go-datastore/Godeps/_workspace/src/github.com/jbenet/go-os-rename"
 	"github.com/jbenet/go-datastore/query"
 )
 
@@ -124,7 +125,7 @@ func (fs *Datastore) Put(key datastore.Key, value interface{}) error {
 	}
 	closed = true
 
-	err = os.Rename(tmp.Name(), path)
+	err = osrename.Rename(tmp.Name(), path)
 	if err != nil {
 		return err
 	}

--- a/flatfs/flatfs_test.go
+++ b/flatfs/flatfs_test.go
@@ -148,7 +148,7 @@ func TestStorage(t *testing.T) {
 
 	const prefixLen = 2
 	const prefix = "7175"
-	const target = prefix + "/71757578.data"
+	const target = prefix + string(os.PathSeparator) + "71757578.data"
 	fs, err := flatfs.New(temp, prefixLen)
 	if err != nil {
 		t.Fatalf("New fail: %v\n", err)

--- a/flatfs/flatfs_test.go
+++ b/flatfs/flatfs_test.go
@@ -147,8 +147,8 @@ func TestStorage(t *testing.T) {
 	defer cleanup()
 
 	const prefixLen = 2
-	const prefix = "2f71"
-	const target = prefix + "/2f71757578.data"
+	const prefix = "7175"
+	const target = prefix + "/71757578.data"
 	fs, err := flatfs.New(temp, prefixLen)
 	if err != nil {
 		t.Fatalf("New fail: %v\n", err)

--- a/flatfs/flatfs_test.go
+++ b/flatfs/flatfs_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/jbenet/go-datastore"
@@ -182,8 +183,10 @@ func TestStorage(t *testing.T) {
 			if !fi.Mode().IsRegular() {
 				t.Errorf("expected a regular file, mode: %04o", fi.Mode())
 			}
-			if g, e := fi.Mode()&os.ModePerm&0007, os.FileMode(0000); g != e {
-				t.Errorf("file should not be world accessible: %04o", fi.Mode())
+			if runtime.GOOS != "windows" {
+				if g, e := fi.Mode()&os.ModePerm&0007, os.FileMode(0000); g != e {
+					t.Errorf("file should not be world accessible: %04o", fi.Mode())
+				}
 			}
 		default:
 			t.Errorf("saw unexpected directory entry: %q %v", path, fi.Mode())

--- a/flatfs/sync_std.go
+++ b/flatfs/sync_std.go
@@ -1,0 +1,17 @@
+// +build !windows
+
+package flatfs
+
+import "os"
+
+func syncDir(dir string) error {
+	dirF, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer dirF.Close()
+	if err := dirF.Sync(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/flatfs/sync_windows.go
+++ b/flatfs/sync_windows.go
@@ -1,0 +1,5 @@
+package flatfs
+
+func syncDir(dir string) error {
+	return nil
+}


### PR DESCRIPTION
Untested on Windows, hoping some kind soul on IRC will do that.

To test, run whatever is the Windows equivalent of:

```
go get github.com/jbenet/go-datastore && cd $GOPATH/src/github.com/jbenet/go-datastore && git remote add tv42 https://github.com/tv42/go-datastore && git fetch tv42 && git checkout flatfs-rides-again && go test ./flatfs
```
