### PR TITLE
add in support for batched writes

### DIFF
--- a/basic_ds.go
+++ b/basic_ds.go
@@ -63,6 +63,10 @@ func (d *MapDatastore) Query(q dsq.Query) (dsq.Results, error) {
 	return r, nil
 }
 
+func (d *MapDatastore) StartBatchOp() Transaction {
+	return NewBasicTransaction(d)
+}
+
 // NullDatastore stores nothing, but conforms to the API.
 // Useful to test with.
 type NullDatastore struct {
@@ -96,6 +100,10 @@ func (d *NullDatastore) Delete(key Key) (err error) {
 // Query implements Datastore.Query
 func (d *NullDatastore) Query(q dsq.Query) (dsq.Results, error) {
 	return dsq.ResultsWithEntries(q, nil), nil
+}
+
+func (d *NullDatastore) StartBatchOp() Transaction {
+	return NewBasicTransaction(d)
 }
 
 // LogDatastore logs all accesses through the datastore.
@@ -153,4 +161,9 @@ func (d *LogDatastore) Delete(key Key) (err error) {
 func (d *LogDatastore) Query(q dsq.Query) (dsq.Results, error) {
 	log.Printf("%s: Query\n", d.Name)
 	return d.child.Query(q)
+}
+
+func (d *LogDatastore) StartBatchOp() Transaction {
+	log.Printf("%s: StartBatchOp\n", d.Name)
+	return d.child.StartBatchOp()
 }

--- a/basic_ds.go
+++ b/basic_ds.go
@@ -63,8 +63,8 @@ func (d *MapDatastore) Query(q dsq.Query) (dsq.Results, error) {
 	return r, nil
 }
 
-func (d *MapDatastore) StartBatchOp() Transaction {
-	return NewBasicTransaction(d)
+func (d *MapDatastore) Batch() Batch {
+	return NewBasicBatch(d)
 }
 
 // NullDatastore stores nothing, but conforms to the API.
@@ -102,8 +102,8 @@ func (d *NullDatastore) Query(q dsq.Query) (dsq.Results, error) {
 	return dsq.ResultsWithEntries(q, nil), nil
 }
 
-func (d *NullDatastore) StartBatchOp() Transaction {
-	return NewBasicTransaction(d)
+func (d *NullDatastore) Batch() Batch {
+	return NewBasicBatch(d)
 }
 
 // LogDatastore logs all accesses through the datastore.
@@ -163,7 +163,7 @@ func (d *LogDatastore) Query(q dsq.Query) (dsq.Results, error) {
 	return d.child.Query(q)
 }
 
-func (d *LogDatastore) StartBatchOp() Transaction {
-	log.Printf("%s: StartBatchOp\n", d.Name)
-	return d.child.StartBatchOp()
+func (d *LogDatastore) Batch() Batch {
+	log.Printf("%s: Batch\n", d.Name)
+	return d.child.Batch()
 }

--- a/callback/callback.go
+++ b/callback/callback.go
@@ -40,3 +40,8 @@ func (c *Datastore) Query(q dsq.Query) (dsq.Results, error) {
 	c.F()
 	return c.D.Query(q)
 }
+
+func (c *Datastore) StartBatchOp() ds.Transaction {
+	c.F()
+	return c.D.StartBatchOp()
+}

--- a/callback/callback.go
+++ b/callback/callback.go
@@ -41,7 +41,7 @@ func (c *Datastore) Query(q dsq.Query) (dsq.Results, error) {
 	return c.D.Query(q)
 }
 
-func (c *Datastore) StartBatchOp() ds.Transaction {
+func (c *Datastore) Batch() ds.Batch {
 	c.F()
-	return c.D.StartBatchOp()
+	return c.D.Batch()
 }

--- a/coalesce/coalesce.go
+++ b/coalesce/coalesce.go
@@ -124,3 +124,7 @@ func (d *datastore) Query(q dsq.Query) (dsq.Results, error) {
 	// query not coalesced yet.
 	return d.child.Query(q)
 }
+
+func (d *datastore) StartBatchOp() ds.Transaction {
+	return ds.NewBasicTransaction(d)
+}

--- a/coalesce/coalesce.go
+++ b/coalesce/coalesce.go
@@ -125,6 +125,6 @@ func (d *datastore) Query(q dsq.Query) (dsq.Results, error) {
 	return d.child.Query(q)
 }
 
-func (d *datastore) StartBatchOp() ds.Transaction {
-	return ds.NewBasicTransaction(d)
+func (d *datastore) Batch() ds.Batch {
+	return ds.NewBasicBatch(d)
 }

--- a/datastore.go
+++ b/datastore.go
@@ -68,8 +68,8 @@ type Datastore interface {
 	//
 	Query(q query.Query) (query.Results, error)
 
-	// StartBatchOp begins a datastore transaction
-	StartBatchOp() Transaction
+	// Batch begins a datastore transaction
+	Batch() Batch
 }
 
 // ThreadSafeDatastore is an interface that all threadsafe datastore should
@@ -108,7 +108,7 @@ func GetBackedHas(ds Datastore, key Key) (bool, error) {
 	}
 }
 
-type Transaction interface {
+type Batch interface {
 	Put(key Key, val interface{}) error
 
 	Delete(key Key) error

--- a/datastore.go
+++ b/datastore.go
@@ -67,6 +67,9 @@ type Datastore interface {
 	//   result.AllEntries()
 	//
 	Query(q query.Query) (query.Results, error)
+
+	// StartBatchOp begins a datastore transaction
+	StartBatchOp() Transaction
 }
 
 // ThreadSafeDatastore is an interface that all threadsafe datastore should
@@ -103,4 +106,12 @@ func GetBackedHas(ds Datastore, key Key) (bool, error) {
 	default:
 		return false, err
 	}
+}
+
+type Transaction interface {
+	Put(key Key, val interface{}) error
+
+	Delete(key Key) error
+
+	Commit() error
 }

--- a/flatfs/flatfs.go
+++ b/flatfs/flatfs.go
@@ -323,32 +323,32 @@ func (fs *Datastore) enumerateKeys(fi os.FileInfo, res []query.Entry) ([]query.E
 	return res, nil
 }
 
-type flatfsTransaction struct {
+type flatfsBatch struct {
 	puts    map[datastore.Key]interface{}
 	deletes map[datastore.Key]struct{}
 
 	ds *Datastore
 }
 
-func (fs *Datastore) StartBatchOp() datastore.Transaction {
-	return &flatfsTransaction{
+func (fs *Datastore) Batch() datastore.Batch {
+	return &flatfsBatch{
 		puts:    make(map[datastore.Key]interface{}),
 		deletes: make(map[datastore.Key]struct{}),
 		ds:      fs,
 	}
 }
 
-func (bt *flatfsTransaction) Put(key datastore.Key, val interface{}) error {
+func (bt *flatfsBatch) Put(key datastore.Key, val interface{}) error {
 	bt.puts[key] = val
 	return nil
 }
 
-func (bt *flatfsTransaction) Delete(key datastore.Key) error {
+func (bt *flatfsBatch) Delete(key datastore.Key) error {
 	bt.deletes[key] = struct{}{}
 	return nil
 }
 
-func (bt *flatfsTransaction) Commit() error {
+func (bt *flatfsBatch) Commit() error {
 	if err := bt.ds.putMany(bt.puts); err != nil {
 		return err
 	}

--- a/flatfs/flatfs.go
+++ b/flatfs/flatfs.go
@@ -68,12 +68,8 @@ func (fs *Datastore) decode(file string) (key datastore.Key, ok bool) {
 }
 
 func (fs *Datastore) makePrefixDir(dir string) error {
-	if err := os.Mkdir(dir, 0777); err != nil {
-		// EEXIST is safe to ignore here, that just means the prefix
-		// directory already existed.
-		if !os.IsExist(err) {
-			return err
-		}
+	if err := fs.makePrefixDirNoSync(dir); err != nil {
+		return err
 	}
 
 	// In theory, if we create a new prefix dir and add a file to
@@ -82,6 +78,17 @@ func (fs *Datastore) makePrefixDir(dir string) error {
 	// a prefix dir, just to be paranoid.
 	if err := syncDir(fs.path); err != nil {
 		return err
+	}
+	return nil
+}
+
+func (fs *Datastore) makePrefixDirNoSync(dir string) error {
+	if err := os.Mkdir(dir, 0777); err != nil {
+		// EEXIST is safe to ignore here, that just means the prefix
+		// directory already existed.
+		if !os.IsExist(err) {
+			return err
+		}
 	}
 	return nil
 }
@@ -134,6 +141,88 @@ func (fs *Datastore) Put(key datastore.Key, value interface{}) error {
 	if err := syncDir(dir); err != nil {
 		return err
 	}
+	return nil
+}
+
+func (fs *Datastore) putMany(data map[datastore.Key]interface{}) error {
+	var dirsToSync []string
+	files := make(map[*os.File]string)
+
+	for key, value := range data {
+		val, ok := value.([]byte)
+		if !ok {
+			return datastore.ErrInvalidType
+		}
+		dir, path := fs.encode(key)
+		if err := fs.makePrefixDirNoSync(dir); err != nil {
+			return err
+		}
+		dirsToSync = append(dirsToSync, dir)
+
+		tmp, err := ioutil.TempFile(dir, "put-")
+		if err != nil {
+			return err
+		}
+
+		if _, err := tmp.Write(val); err != nil {
+			return err
+		}
+
+		files[tmp] = path
+	}
+
+	ops := make(map[*os.File]int)
+
+	defer func() {
+		for fi, _ := range files {
+			val, _ := ops[fi]
+			switch val {
+			case 0:
+				_ = fi.Close()
+				fallthrough
+			case 1:
+				_ = os.Remove(fi.Name())
+			}
+		}
+	}()
+
+	// Now we sync everything
+	// sync and close files
+	for fi, _ := range files {
+		if err := fi.Sync(); err != nil {
+			return err
+		}
+
+		if err := fi.Close(); err != nil {
+			return err
+		}
+
+		// signify closed
+		ops[fi] = 1
+	}
+
+	// move files to their proper places
+	for fi, path := range files {
+		if err := osrename.Rename(fi.Name(), path); err != nil {
+			return err
+		}
+
+		// signify removed
+		ops[fi] = 2
+	}
+
+	// now sync the dirs for those files
+	for _, dir := range dirsToSync {
+		if err := syncDir(dir); err != nil {
+			return err
+		}
+	}
+
+	// sync top flatfs dir
+	if err := syncDir(fs.path); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -232,6 +321,45 @@ func (fs *Datastore) enumerateKeys(fi os.FileInfo, res []query.Entry) ([]query.E
 		res = append(res, query.Entry{Key: key.String()})
 	}
 	return res, nil
+}
+
+type flatfsTransaction struct {
+	puts    map[datastore.Key]interface{}
+	deletes map[datastore.Key]struct{}
+
+	ds *Datastore
+}
+
+func (fs *Datastore) StartBatchOp() datastore.Transaction {
+	return &flatfsTransaction{
+		puts:    make(map[datastore.Key]interface{}),
+		deletes: make(map[datastore.Key]struct{}),
+		ds:      fs,
+	}
+}
+
+func (bt *flatfsTransaction) Put(key datastore.Key, val interface{}) error {
+	bt.puts[key] = val
+	return nil
+}
+
+func (bt *flatfsTransaction) Delete(key datastore.Key) error {
+	bt.deletes[key] = struct{}{}
+	return nil
+}
+
+func (bt *flatfsTransaction) Commit() error {
+	if err := bt.ds.putMany(bt.puts); err != nil {
+		return err
+	}
+
+	for k, _ := range bt.deletes {
+		if err := bt.ds.Delete(k); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 var _ datastore.ThreadSafeDatastore = (*Datastore)(nil)

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -130,10 +130,10 @@ func (d *Datastore) Query(q query.Query) (query.Results, error) {
 	return r, nil
 }
 
-func (d *Datastore) StartBatchOp() ds.Transaction {
+func (d *Datastore) Batch() ds.Batch {
 	// just use basic transaction for now, this datastore
 	// isnt really used in performant code yet
-	return ds.NewBasicTransaction(d)
+	return ds.NewBasicBatch(d)
 }
 
 // isDir returns whether given path is a directory

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -130,6 +130,12 @@ func (d *Datastore) Query(q query.Query) (query.Results, error) {
 	return r, nil
 }
 
+func (d *Datastore) StartBatchOp() ds.Transaction {
+	// just use basic transaction for now, this datastore
+	// isnt really used in performant code yet
+	return ds.NewBasicTransaction(d)
+}
+
 // isDir returns whether given path is a directory
 func isDir(path string) bool {
 	finfo, err := os.Stat(path)

--- a/keytransform/keytransform.go
+++ b/keytransform/keytransform.go
@@ -74,27 +74,27 @@ func (d *ktds) Query(q dsq.Query) (dsq.Results, error) {
 	return dsq.DerivedResults(qr, ch), nil
 }
 
-func (d *ktds) StartBatchOp() ds.Transaction {
-	return &transformTransaction{
-		dst: d.child.StartBatchOp(),
+func (d *ktds) Batch() ds.Batch {
+	return &transformBatch{
+		dst: d.child.Batch(),
 		f:   d.ConvertKey,
 	}
 }
 
-type transformTransaction struct {
-	dst ds.Transaction
+type transformBatch struct {
+	dst ds.Batch
 
 	f KeyMapping
 }
 
-func (t *transformTransaction) Put(key ds.Key, val interface{}) error {
+func (t *transformBatch) Put(key ds.Key, val interface{}) error {
 	return t.dst.Put(t.f(key), val)
 }
 
-func (t *transformTransaction) Delete(key ds.Key) error {
+func (t *transformBatch) Delete(key ds.Key) error {
 	return t.dst.Delete(t.f(key))
 }
 
-func (t *transformTransaction) Commit() error {
+func (t *transformBatch) Commit() error {
 	return t.dst.Commit()
 }

--- a/keytransform/keytransform.go
+++ b/keytransform/keytransform.go
@@ -73,3 +73,28 @@ func (d *ktds) Query(q dsq.Query) (dsq.Results, error) {
 
 	return dsq.DerivedResults(qr, ch), nil
 }
+
+func (d *ktds) StartBatchOp() ds.Transaction {
+	return &transformTransaction{
+		dst: d.child.StartBatchOp(),
+		f:   d.ConvertKey,
+	}
+}
+
+type transformTransaction struct {
+	dst ds.Transaction
+
+	f KeyMapping
+}
+
+func (t *transformTransaction) Put(key ds.Key, val interface{}) error {
+	return t.dst.Put(t.f(key), val)
+}
+
+func (t *transformTransaction) Delete(key ds.Key) error {
+	return t.dst.Delete(t.f(key))
+}
+
+func (t *transformTransaction) Commit() error {
+	return t.dst.Commit()
+}

--- a/leveldb/datastore.go
+++ b/leveldb/datastore.go
@@ -100,6 +100,40 @@ func (d *datastore) Query(q dsq.Query) (dsq.Results, error) {
 	return qr, nil
 }
 
+type ldbBatch struct {
+	b *leveldb.Batch
+	d *datastore
+}
+
+func (d *datastore) StartBatchOp() ds.Transaction {
+	return &ldbBatch{
+		b: new(leveldb.Batch),
+		d: d,
+	}
+}
+
+func (b *ldbBatch) Put(key ds.Key, val interface{}) error {
+	v, ok := val.([]byte)
+	if !ok {
+		return ds.ErrInvalidType
+	}
+	b.b.Put(key.Bytes(), v) // #dealwithit
+	return nil
+}
+
+func (b *ldbBatch) Delete(key ds.Key) error {
+	b.b.Delete(key.Bytes())
+	return nil
+}
+
+func (b *ldbBatch) Commit() error {
+	opts := &opt.WriteOptions{Sync: true}
+	if err := b.d.DB.Write(b.b, opts); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (d *datastore) runQuery(worker goprocess.Process, qrb *dsq.ResultBuilder) {
 
 	var rnge *util.Range

--- a/leveldb/datastore.go
+++ b/leveldb/datastore.go
@@ -105,7 +105,7 @@ type ldbBatch struct {
 	d *datastore
 }
 
-func (d *datastore) StartBatchOp() ds.Transaction {
+func (d *datastore) Batch() ds.Batch {
 	return &ldbBatch{
 		b: new(leveldb.Batch),
 		d: d,

--- a/lru/datastore.go
+++ b/lru/datastore.go
@@ -55,6 +55,6 @@ func (d *Datastore) Query(q dsq.Query) (dsq.Results, error) {
 	return nil, errors.New("KeyList not implemented.")
 }
 
-func (d *Datastore) StartBatchOp() ds.Transaction {
-	return ds.NewBasicTransaction(d)
+func (d *Datastore) Batch() ds.Batch {
+	return ds.NewBasicBatch(d)
 }

--- a/lru/datastore.go
+++ b/lru/datastore.go
@@ -54,3 +54,7 @@ func (d *Datastore) Delete(key ds.Key) (err error) {
 func (d *Datastore) Query(q dsq.Query) (dsq.Results, error) {
 	return nil, errors.New("KeyList not implemented.")
 }
+
+func (d *Datastore) StartBatchOp() ds.Transaction {
+	return ds.NewBasicTransaction(d)
+}

--- a/measure/measure.go
+++ b/measure/measure.go
@@ -148,36 +148,36 @@ func (m *measure) Query(q query.Query) (query.Results, error) {
 	return res, err
 }
 
-type measuredTransaction struct {
+type measuredBatch struct {
 	puts    int
 	deletes int
 
-	putts datastore.Transaction
-	delts datastore.Transaction
+	putts datastore.Batch
+	delts datastore.Batch
 
 	m *measure
 }
 
-func (m *measure) StartBatchOp() datastore.Transaction {
-	return &measuredTransaction{
-		putts: m.backend.StartBatchOp(),
-		delts: m.backend.StartBatchOp(),
+func (m *measure) Batch() datastore.Batch {
+	return &measuredBatch{
+		putts: m.backend.Batch(),
+		delts: m.backend.Batch(),
 
 		m: m,
 	}
 }
 
-func (mt *measuredTransaction) Put(key datastore.Key, val interface{}) error {
+func (mt *measuredBatch) Put(key datastore.Key, val interface{}) error {
 	mt.puts++
 	return mt.putts.Put(key, val)
 }
 
-func (mt *measuredTransaction) Delete(key datastore.Key) error {
+func (mt *measuredBatch) Delete(key datastore.Key) error {
 	mt.deletes++
 	return mt.delts.Delete(key)
 }
 
-func (mt *measuredTransaction) Commit() error {
+func (mt *measuredBatch) Commit() error {
 	if mt.deletes > 0 {
 		before := time.Now()
 		err := mt.delts.Commit()

--- a/panic/panic.go
+++ b/panic/panic.go
@@ -67,11 +67,11 @@ func (d *datastore) Query(q dsq.Query) (dsq.Results, error) {
 	return r, nil
 }
 
-type panicTransaction struct {
-	t ds.Transaction
+type panicBatch struct {
+	t ds.Batch
 }
 
-func (p *panicTransaction) Put(key ds.Key, val interface{}) error {
+func (p *panicBatch) Put(key ds.Key, val interface{}) error {
 	err := p.t.Put(key, val)
 	if err != nil {
 		fmt.Fprintf(os.Stdout, "panic datastore: %s", err)
@@ -80,7 +80,7 @@ func (p *panicTransaction) Put(key ds.Key, val interface{}) error {
 	return nil
 }
 
-func (p *panicTransaction) Delete(key ds.Key) error {
+func (p *panicBatch) Delete(key ds.Key) error {
 	err := p.t.Delete(key)
 	if err != nil {
 		fmt.Fprintf(os.Stdout, "panic datastore: %s", err)
@@ -89,7 +89,7 @@ func (p *panicTransaction) Delete(key ds.Key) error {
 	return nil
 }
 
-func (p *panicTransaction) Commit() error {
+func (p *panicBatch) Commit() error {
 	err := p.t.Commit()
 	if err != nil {
 		fmt.Fprintf(os.Stdout, "panic datastore: %s", err)
@@ -98,6 +98,6 @@ func (p *panicTransaction) Commit() error {
 	return nil
 }
 
-func (d *datastore) StartBatchOp() ds.Transaction {
-	return &panicTransaction{d.child.StartBatchOp()}
+func (d *datastore) Batch() ds.Batch {
+	return &panicBatch{d.child.Batch()}
 }

--- a/panic/panic.go
+++ b/panic/panic.go
@@ -66,3 +66,38 @@ func (d *datastore) Query(q dsq.Query) (dsq.Results, error) {
 	}
 	return r, nil
 }
+
+type panicTransaction struct {
+	t ds.Transaction
+}
+
+func (p *panicTransaction) Put(key ds.Key, val interface{}) error {
+	err := p.t.Put(key, val)
+	if err != nil {
+		fmt.Fprintf(os.Stdout, "panic datastore: %s", err)
+		panic("panic datastore: transaction put failed")
+	}
+	return nil
+}
+
+func (p *panicTransaction) Delete(key ds.Key) error {
+	err := p.t.Delete(key)
+	if err != nil {
+		fmt.Fprintf(os.Stdout, "panic datastore: %s", err)
+		panic("panic datastore: transaction delete failed")
+	}
+	return nil
+}
+
+func (p *panicTransaction) Commit() error {
+	err := p.t.Commit()
+	if err != nil {
+		fmt.Fprintf(os.Stdout, "panic datastore: %s", err)
+		panic("panic datastore: transaction commit failed")
+	}
+	return nil
+}
+
+func (d *datastore) StartBatchOp() ds.Transaction {
+	return &panicTransaction{d.child.StartBatchOp()}
+}

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -64,8 +64,8 @@ func (d *MutexDatastore) Query(q dsq.Query) (dsq.Results, error) {
 	return d.child.Query(q)
 }
 
-func (d *MutexDatastore) StartBatchOp() ds.Transaction {
+func (d *MutexDatastore) Batch() ds.Batch {
 	d.RLock()
 	defer d.RUnlock()
-	return d.child.StartBatchOp()
+	return d.child.Batch()
 }

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -63,3 +63,9 @@ func (d *MutexDatastore) Query(q dsq.Query) (dsq.Results, error) {
 	defer d.RUnlock()
 	return d.child.Query(q)
 }
+
+func (d *MutexDatastore) StartBatchOp() ds.Transaction {
+	d.RLock()
+	defer d.RUnlock()
+	return d.child.StartBatchOp()
+}

--- a/tiered/tiered.go
+++ b/tiered/tiered.go
@@ -93,17 +93,17 @@ func (d tiered) Query(q dsq.Query) (dsq.Results, error) {
 	return d[len(d)-1].Query(q)
 }
 
-type tieredTransaction []ds.Transaction
+type tieredBatch []ds.Batch
 
-func (d tiered) StartBatchOp() ds.Transaction {
-	var out tieredTransaction
+func (d tiered) Batch() ds.Batch {
+	var out tieredBatch
 	for _, ds := range d {
-		out = append(out, ds.StartBatchOp())
+		out = append(out, ds.Batch())
 	}
 	return out
 }
 
-func (t tieredTransaction) Put(key ds.Key, val interface{}) error {
+func (t tieredBatch) Put(key ds.Key, val interface{}) error {
 	for _, ts := range t {
 		err := ts.Put(key, val)
 		if err != nil {
@@ -113,7 +113,7 @@ func (t tieredTransaction) Put(key ds.Key, val interface{}) error {
 	return nil
 }
 
-func (t tieredTransaction) Delete(key ds.Key) error {
+func (t tieredBatch) Delete(key ds.Key) error {
 	for _, ts := range t {
 		err := ts.Delete(key)
 		if err != nil {
@@ -123,7 +123,7 @@ func (t tieredTransaction) Delete(key ds.Key) error {
 	return nil
 }
 
-func (t tieredTransaction) Commit() error {
+func (t tieredBatch) Commit() error {
 	for _, ts := range t {
 		err := ts.Commit()
 		if err != nil {

--- a/tiered/tiered.go
+++ b/tiered/tiered.go
@@ -92,3 +92,43 @@ func (d tiered) Query(q dsq.Query) (dsq.Results, error) {
 	// query always the last (most complete) one
 	return d[len(d)-1].Query(q)
 }
+
+type tieredTransaction []ds.Transaction
+
+func (d tiered) StartBatchOp() ds.Transaction {
+	var out tieredTransaction
+	for _, ds := range d {
+		out = append(out, ds.StartBatchOp())
+	}
+	return out
+}
+
+func (t tieredTransaction) Put(key ds.Key, val interface{}) error {
+	for _, ts := range t {
+		err := ts.Put(key, val)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t tieredTransaction) Delete(key ds.Key) error {
+	for _, ts := range t {
+		err := ts.Delete(key)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t tieredTransaction) Commit() error {
+	for _, ts := range t {
+		err := ts.Commit()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/timecache/timecache.go
+++ b/timecache/timecache.go
@@ -95,7 +95,7 @@ func (d *datastore) Query(q dsq.Query) (dsq.Results, error) {
 	return d.cache.Query(q)
 }
 
-func (d *datastore) StartBatchOp() ds.Transaction {
+func (d *datastore) Batch() ds.Batch {
 	// sorry, being lazy here
-	return ds.NewBasicTransaction(d)
+	return ds.NewBasicBatch(d)
 }

--- a/timecache/timecache.go
+++ b/timecache/timecache.go
@@ -94,3 +94,8 @@ func (d *datastore) Delete(key ds.Key) (err error) {
 func (d *datastore) Query(q dsq.Query) (dsq.Results, error) {
 	return d.cache.Query(q)
 }
+
+func (d *datastore) StartBatchOp() ds.Transaction {
+	// sorry, being lazy here
+	return ds.NewBasicTransaction(d)
+}

--- a/transaction.go
+++ b/transaction.go
@@ -1,33 +1,33 @@
 package datastore
 
-// basicTransaction implements the transaction interface for datastores who do
+// basicBatch implements the transaction interface for datastores who do
 // not have any sort of underlying transactional support
-type basicTransaction struct {
+type basicBatch struct {
 	puts    map[Key]interface{}
 	deletes map[Key]struct{}
 
 	target Datastore
 }
 
-func NewBasicTransaction(ds Datastore) Transaction {
-	return &basicTransaction{
+func NewBasicBatch(ds Datastore) Batch {
+	return &basicBatch{
 		puts:    make(map[Key]interface{}),
 		deletes: make(map[Key]struct{}),
 		target:  ds,
 	}
 }
 
-func (bt *basicTransaction) Put(key Key, val interface{}) error {
+func (bt *basicBatch) Put(key Key, val interface{}) error {
 	bt.puts[key] = val
 	return nil
 }
 
-func (bt *basicTransaction) Delete(key Key) error {
+func (bt *basicBatch) Delete(key Key) error {
 	bt.deletes[key] = struct{}{}
 	return nil
 }
 
-func (bt *basicTransaction) Commit() error {
+func (bt *basicBatch) Commit() error {
 	for k, val := range bt.puts {
 		if err := bt.target.Put(k, val); err != nil {
 			return err

--- a/transaction.go
+++ b/transaction.go
@@ -1,0 +1,44 @@
+package datastore
+
+// basicTransaction implements the transaction interface for datastores who do
+// not have any sort of underlying transactional support
+type basicTransaction struct {
+	puts    map[Key]interface{}
+	deletes map[Key]struct{}
+
+	target Datastore
+}
+
+func NewBasicTransaction(ds Datastore) Transaction {
+	return &basicTransaction{
+		puts:    make(map[Key]interface{}),
+		deletes: make(map[Key]struct{}),
+		target:  ds,
+	}
+}
+
+func (bt *basicTransaction) Put(key Key, val interface{}) error {
+	bt.puts[key] = val
+	return nil
+}
+
+func (bt *basicTransaction) Delete(key Key) error {
+	bt.deletes[key] = struct{}{}
+	return nil
+}
+
+func (bt *basicTransaction) Commit() error {
+	for k, val := range bt.puts {
+		if err := bt.target.Put(k, val); err != nil {
+			return err
+		}
+	}
+
+	for k, _ := range bt.deletes {
+		if err := bt.target.Delete(k); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This implements a transaction object to allow for puts and deletes to be combined into a single operation. On certain backends this provides very significant performance improvements. Testing flatfs on my 700MB/s read/write SSD with 20MB worth of 100k writes showed a nearly 3x performance improvement (operation went from taking 1.6seconds to about 0.6 seconds)
