### PR TITLE
fix locking in syncbatch

### DIFF
--- a/sync/sync.go
+++ b/sync/sync.go
@@ -92,24 +92,24 @@ func (d *MutexDatastore) Close() error {
 }
 
 type syncBatch struct {
-	lk    sync.Mutex
 	batch ds.Batch
+	mds   *MutexDatastore
 }
 
 func (b *syncBatch) Put(key ds.Key, val interface{}) error {
-	b.lk.Lock()
-	defer b.lk.Unlock()
+	b.mds.Lock()
+	defer b.mds.Unlock()
 	return b.batch.Put(key, val)
 }
 
 func (b *syncBatch) Delete(key ds.Key) error {
-	b.lk.Lock()
-	defer b.lk.Unlock()
+	b.mds.Lock()
+	defer b.mds.Unlock()
 	return b.batch.Delete(key)
 }
 
 func (b *syncBatch) Commit() error {
-	b.lk.Lock()
-	defer b.lk.Unlock()
+	b.mds.Lock()
+	defer b.mds.Unlock()
 	return b.batch.Commit()
 }


### PR DESCRIPTION
If the batch returned by the underlying batching datastore isnt properly locked, calling commit on the  batch (even if it takes its lock) doesnt respect the lock in the MutexDatastore that we are using to protect the given datastore. This uses the lock on the MutexDatastore to do all locking for the child batch.

It uses it for all batch operations as some batches may write to the datastore outside of commit being called.
