### PR TITLE
Print formatted string using Errorf

### DIFF
--- a/flatfs/flatfs.go
+++ b/flatfs/flatfs.go
@@ -124,7 +124,7 @@ func (fs *Datastore) Put(key datastore.Key, value interface{}) error {
 			return err
 		}
 
-		log.Error("too many open files, retrying in %dms", 100*i)
+		log.Errorf("too many open files, retrying in %dms", 100*i)
 		time.Sleep(time.Millisecond * 100 * time.Duration(i))
 	}
 	return err


### PR DESCRIPTION
Hi,

Currently `log.Error` is used with a formatted string, causing output of the form:

```
flatfs: too many open files, retrying in %dms0 flatfs.go:119
```

Switched `log.Error` with `log.Errorf`.
