### PR TITLE
In the measure package don't return ErrInvalidType in batch Put.

### DIFF
--- a/measure/measure.go
+++ b/measure/measure.go
@@ -179,10 +179,9 @@ func (m *measure) Batch() (datastore.Batch, error) {
 func (mt *measuredBatch) Put(key datastore.Key, val interface{}) error {
 	mt.puts++
 	valb, ok := val.([]byte)
-	if !ok {
-		return datastore.ErrInvalidType
+	if ok {
+		_ = mt.m.putSize.RecordValue(int64(len(valb)))
 	}
-	_ = mt.m.putSize.RecordValue(int64(len(valb)))
 	return mt.putts.Put(key, val)
 }
 


### PR DESCRIPTION
None of the other methods in the measure package return this error,
instead they only call RecordValue() when the value is []byte.  This
change makes batch Put consistent with the other methods and allows
non []byte data to be passed though the measure datastore.

License: MIT
Signed-off-by: Kevin Atkinson <k@kevina.org>