### PR TITLE
Fix bug in LevelDB datastore's Delete() method.

### DIFF
--- a/leveldb/datastore.go
+++ b/leveldb/datastore.go
@@ -58,11 +58,17 @@ func (d *datastore) Has(key ds.Key) (exists bool, err error) {
 }
 
 func (d *datastore) Delete(key ds.Key) (err error) {
-	err = d.DB.Delete(key.Bytes(), nil)
-	if err == leveldb.ErrNotFound {
+	// leveldb Delete will not return an error if the key doesn't
+	// exist (see https://github.com/syndtr/goleveldb/issues/109),
+	// so check that the key exists first and if not return an
+	// error
+	exists, err := d.DB.Has(key.Bytes(), nil)
+	if !exists {
 		return ds.ErrNotFound
+	} else if err != nil {
+		return err
 	}
-	return err
+	return d.DB.Delete(key.Bytes(), nil)
 }
 
 func (d *datastore) Query(q dsq.Query) (dsq.Results, error) {


### PR DESCRIPTION
LevelDB Delete() method will not return ErrNotFound, so check that the
key exists first by calling Has() and return ds.ErrNotFound if Has()
returns false.

License: MIT
Signed-off-by: Kevin Atkinson <k@kevina.org>