### PR TITLE
remove hex encoding from flatfs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.3
+  - 1.6.2
   - release
   - tip
 

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,12 @@
-build:
-	go build
+test: deps
+	go test -race -v ./...
 
-test: build
-	go test -race -cpu=5 -v ./...
+export IPFS_API ?= v04x.ipfs.io
 
-# saves/vendors third-party dependencies to Godeps/_workspace
-# -r flag rewrites import paths to use the vendored path
-# ./... performs operation on all packages in tree
-vendor: godep
-	godep save -r ./...
+gx:
+	go get -u github.com/whyrusleeping/gx
+	go get -u github.com/whyrusleeping/gx-go
 
-deps:
-	go get ./...
+deps: gx
+	gx --verbose install --global
 
-watch:
-	-make
-	@echo "[watching *.go; for recompilation]"
-	# for portability, use watchmedo -- pip install watchmedo
-	@watchmedo shell-command --patterns="*.go;" --recursive \
-		--command='make' .

--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,5 @@ gx:
 
 deps: gx
 	gx --verbose install --global
+	gx-go rewrite
 

--- a/flatfs/flatfs_test.go
+++ b/flatfs/flatfs_test.go
@@ -152,8 +152,8 @@ func TestStorage(t *testing.T) {
 	defer cleanup()
 
 	const prefixLen = 2
-	const prefix = "7175"
-	const target = prefix + string(os.PathSeparator) + "71757578.data"
+	const prefix = "q"
+	const target = prefix + string(os.PathSeparator) + "quux.data"
 	fs, err := flatfs.New(temp, prefixLen, false)
 	if err != nil {
 		t.Fatalf("New fail: %v\n", err)


### PR DESCRIPTION
with the changes being made to go-ipfs to base64 encode all keys (previously they were binary). It is safe to assume that inputs to flatfs are path safe.

This PR isnt strictly necessary, but it avoids an extra layer of encoding

cc @Kubuxu @kevina 
