### PR TITLE
Set the channel buffer size to 128 for KeysOnly queries.

### DIFF
--- a/flatfs/flatfs.go
+++ b/flatfs/flatfs.go
@@ -309,7 +309,7 @@ func (fs *Datastore) Query(q query.Query) (query.Results, error) {
 		return nil, errors.New("flatfs only supports listing all keys in random order")
 	}
 
-	reschan := make(chan query.Result)
+	reschan := make(chan query.Result, query.KeysOnlyBufSize)
 	go func() {
 		defer close(reschan)
 		err := filepath.Walk(fs.path, func(path string, info os.FileInfo, err error) error {

--- a/query/query.go
+++ b/query/query.go
@@ -179,10 +179,16 @@ func (rb *ResultBuilder) Results() Results {
 	}
 }
 
+const KeysOnlyBufSize = 128
+
 func NewResultBuilder(q Query) *ResultBuilder {
+	bufSize := 1
+	if q.KeysOnly {
+		bufSize = KeysOnlyBufSize
+	}
 	b := &ResultBuilder{
 		Query:  q,
-		Output: make(chan Result),
+		Output: make(chan Result, bufSize),
 	}
 	b.Process = goprocess.WithTeardown(func() error {
 		close(b.Output)


### PR DESCRIPTION
Relates to #40.
