### PR TITLE
add non-channel query iterator method

### DIFF
--- a/key.go
+++ b/key.go
@@ -4,9 +4,10 @@ import (
 	"path"
 	"strings"
 
-	"github.com/satori/go.uuid"
-
 	dsq "github.com/ipfs/go-datastore/query"
+
+	"github.com/satori/go.uuid"
+	base32 "github.com/whyrusleeping/base32"
 )
 
 /*
@@ -38,6 +39,15 @@ func NewKey(s string) Key {
 	k := Key{s}
 	k.Clean()
 	return k
+}
+
+// RawKey creates a new Key without safety checking the input. Use with care.
+func RawKey(s string) Key {
+	return Key{s}
+}
+
+func NewSafeKey(s string) Key {
+	return Key{base32.RawStdEncoding.EncodeToString([]byte(s))}
 }
 
 // KeyWithNamespaces constructs a key out of a namespace slice.

--- a/query/query.go
+++ b/query/query.go
@@ -106,10 +106,11 @@ type Result struct {
 //   }
 //
 type Results interface {
-	Query() Query           // the query these Results correspond to
-	Next() <-chan Result    // returns a channel to wait for the next result
-	Rest() ([]Entry, error) // waits till processing finishes, returns all entries at once.
-	Close() error           // client may call Close to signal early exit
+	Query() Query             // the query these Results correspond to
+	Next() <-chan Result      // returns a channel to wait for the next result
+	NextSync() (Result, bool) // blocks and waits to return the next result, second paramter returns false when results are exhausted
+	Rest() ([]Entry, error)   // waits till processing finishes, returns all entries at once.
+	Close() error             // client may call Close to signal early exit
 
 	// Process returns a goprocess.Process associated with these results.
 	// most users will not need this function (Close is all they want),
@@ -127,6 +128,11 @@ type results struct {
 
 func (r *results) Next() <-chan Result {
 	return r.res
+}
+
+func (r *results) NextSync() (Result, bool) {
+	val, ok := <-r.res
+	return val, ok
 }
 
 func (r *results) Rest() ([]Entry, error) {


### PR DESCRIPTION
Using channels as query iterators is quite inefficient. A naive implementation of the leveldb query results that avoids using a channel improves perf by close to 20%.