### PR TITLE
Make sure buffer size of wrapper datastores match underlying datastore.

### DIFF
--- a/keytransform/keytransform.go
+++ b/keytransform/keytransform.go
@@ -60,7 +60,7 @@ func (d *ktds) Query(q dsq.Query) (dsq.Results, error) {
 		return nil, err
 	}
 
-	ch := make(chan dsq.Result)
+	ch := make(chan dsq.Result, cap(qr.Next()))
 	go func() {
 		defer close(ch)
 		defer qr.Close()

--- a/namespace/namespace.go
+++ b/namespace/namespace.go
@@ -58,12 +58,7 @@ func (d *datastore) Query(q dsq.Query) (dsq.Results, error) {
 		return nil, err
 	}
 
-	var ch chan dsq.Result
-	if q.KeysOnly {
-		ch = make(chan dsq.Result, dsq.KeysOnlyBufSize)
-	} else {
-		ch = make(chan dsq.Result)
-	}
+	ch := make(chan dsq.Result, cap(qr.Next()))
 
 	go func() {
 		defer close(ch)


### PR DESCRIPTION
This is the way I wanted to fix #52.  It turned out there was yet another channel I didn't notice originally.  With this fix the buffer size of all the channels is now 128 for `blockstore.AllKeysChan()`.

This decreased the time to retrieve 100,000 small (1000 byte) blocks (see ipfs/go-ipfs#3376) from around 340 ms to 245 ms.