### PR TITLE
Add RawKey function and make use of it.

### DIFF
--- a/keytransform/keytransform.go
+++ b/keytransform/keytransform.go
@@ -67,7 +67,7 @@ func (d *ktds) Query(q dsq.Query) (dsq.Results, error) {
 
 		for r := range qr.Next() {
 			if r.Error == nil {
-				r.Entry.Key = d.InvertKey(ds.NewKey(r.Entry.Key)).String()
+				r.Entry.Key = d.InvertKey(ds.RawKey(r.Entry.Key)).String()
 			}
 			ch <- r
 		}

--- a/namespace/namespace.go
+++ b/namespace/namespace.go
@@ -2,7 +2,6 @@ package namespace
 
 import (
 	"fmt"
-	"strings"
 
 	ds "github.com/ipfs/go-datastore"
 	ktds "github.com/ipfs/go-datastore/keytransform"
@@ -29,8 +28,8 @@ func PrefixTransform(prefix ds.Key) ktds.KeyTransform {
 				panic("expected prefix not found")
 			}
 
-			s := strings.TrimPrefix(k.String(), prefix.String())
-			return ds.NewKey(s)
+			s := k.String()[len(prefix.String()):]
+			return ds.RawKey(s)
 		},
 	}
 }
@@ -70,7 +69,7 @@ func (d *datastore) Query(q dsq.Query) (dsq.Results, error) {
 				continue
 			}
 
-			k := ds.NewKey(r.Entry.Key)
+			k := ds.RawKey(r.Entry.Key)
 			if !d.prefix.IsAncestorOf(k) {
 				continue
 			}


### PR DESCRIPTION
Avoids some unnecessary creation of strings.

This decreased the time to retrieve 100,000 small (1000 byte) blocks (see ipfs/go-ipfs#3376) from around 245 ms to 205 ms.