### PR TITLE
Implemented cross-ds query in mount datastore

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.2.0: QmRWDav6mzWseLWeYfVd5fvUKiVe9xNH29YfMF438fG364
+1.2.1: QmSiN66ybp5udnQnvhb6euiWiiQWdGvwMhAWa95cC1DTCV

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.7.3
+  - 1.8
   - tip
 
 script:

--- a/mount/mount.go
+++ b/mount/mount.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/ipfs/go-datastore"
-	"github.com/ipfs/go-datastore/keytransform"
 	"github.com/ipfs/go-datastore/query"
 )
 
@@ -22,27 +21,13 @@ type Mount struct {
 	Datastore datastore.Datastore
 }
 
-type MountSlice []Mount
-
-func (m MountSlice) Len() int {
-	return len(m)
-}
-
-func (m MountSlice) Less(i, j int) bool {
-	return m[i].Prefix.String() > m[j].Prefix.String()
-}
-
-func (m MountSlice) Swap(i, j int) {
-	m[i], m[j] = m[j], m[i]
-}
-
 func New(mounts []Mount) *Datastore {
 	// make a copy so we're sure it doesn't mutate
 	m := make([]Mount, len(mounts))
 	for i, v := range mounts {
 		m[i] = v
 	}
-	sort.Sort(MountSlice(m))
+	sort.Slice(m, func(i, j int) bool { return m[i].Prefix.String() > m[j].Prefix.String() })
 	return &Datastore{mounts: m}
 }
 
@@ -61,6 +46,38 @@ func (d *Datastore) lookup(key datastore.Key) (ds datastore.Datastore, mountpoin
 		}
 	}
 	return nil, datastore.NewKey("/"), key
+}
+
+// lookupAll returns all mounts that might contain keys that are descendant of <key>
+//
+// Matching: /ao/e
+//
+// /          B /ao/e
+// /a/        not matching
+// /ao/       B /e
+// /ao/e/     A /
+// /ao/e/uh/  A /
+// /aoe/      not matching
+func (d *Datastore) lookupAll(key datastore.Key) (ds []datastore.Datastore, mountpoint, rest []datastore.Key) {
+	for _, m := range d.mounts {
+		p := m.Prefix.String()
+		if len(p) > 1 {
+			p = p + "/"
+		}
+
+		if strings.HasPrefix(p, key.String()) {
+			ds = append(ds, m.Datastore)
+			mountpoint = append(mountpoint, m.Prefix)
+			rest = append(rest, datastore.NewKey("/"))
+		} else if strings.HasPrefix(key.String(), p) {
+			r := strings.TrimPrefix(key.String(), m.Prefix.String())
+
+			ds = append(ds, m.Datastore)
+			mountpoint = append(mountpoint, m.Prefix)
+			rest = append(rest, datastore.NewKey(r))
+		}
+	}
+	return ds, mountpoint, rest
 }
 
 func (d *Datastore) Put(key datastore.Key, value interface{}) error {
@@ -100,36 +117,65 @@ func (d *Datastore) Query(q query.Query) (query.Results, error) {
 		len(q.Orders) > 0 ||
 		q.Limit > 0 ||
 		q.Offset > 0 {
-		// TODO this is overly simplistic, but the only caller is
-		// `ipfs refs local` for now, and this gets us moving.
+		// TODO this is still overly simplistic, but the only callers are
+		// `ipfs refs local` and ipfs-ds-convert.
 		return nil, errors.New("mount only supports listing all prefixed keys in random order")
 	}
-	key := datastore.NewKey(q.Prefix)
-	ds, mount, k := d.lookup(key)
-	if ds == nil {
-		return nil, errors.New("mount only supports listing a mount point")
-	}
-	// TODO support listing cross mount points too
+	prefix := datastore.NewKey(q.Prefix)
+	dses, mounts, rests := d.lookupAll(prefix)
 
-	// delegate the query to the mounted datastore, while adjusting
-	// keys in and out
-	q2 := q
-	q2.Prefix = k.String()
-	wrapDS := keytransform.Wrap(ds, &keytransform.Pair{
-		Convert: func(datastore.Key) datastore.Key {
-			panic("this should never be called")
-		},
-		Invert: func(k datastore.Key) datastore.Key {
-			return mount.Child(k)
-		},
-	})
+	// current itorator state
+	var res query.Results
+	var ds datastore.Datastore
+	var mount datastore.Key
+	var rest datastore.Key
+	i := 0
 
-	r, err := wrapDS.Query(q2)
-	if err != nil {
-		return nil, err
-	}
-	r = query.ResultsReplaceQuery(r, q)
-	return r, nil
+	return query.ResultsFromIterator(q, query.Iterator{
+		Next: func() (query.Result, bool) {
+			var r query.Result
+			var more bool
+
+			for try := true; try; try = len(dses) > i {
+				if ds == nil {
+					if len(dses) <= i {
+						//This should not happen normally
+						return query.Result{}, false
+					}
+
+					ds = dses[i]
+					mount = mounts[i]
+					rest = rests[i]
+
+					q2 := q
+					q2.Prefix = rest.String()
+					r, err := ds.Query(q2)
+					if err != nil {
+						return query.Result{Error: err}, false
+					}
+					res = r
+				}
+
+				r, more = res.NextSync()
+				if !more {
+					ds = nil
+					i++
+					more = len(dses) > i
+				} else {
+					break
+				}
+			}
+
+			r.Key = mount.Child(datastore.RawKey(r.Key)).String()
+			return r, more
+		},
+		Close: func() error {
+			if len(mounts) > i {
+				return res.Close()
+			}
+			return nil
+		},
+	}), nil
 }
 
 func (d *Datastore) Close() error {

--- a/mount/mount.go
+++ b/mount/mount.go
@@ -5,6 +5,7 @@ package mount
 import (
 	"errors"
 	"io"
+	"sort"
 	"strings"
 
 	"github.com/ipfs/go-datastore"
@@ -21,12 +22,27 @@ type Mount struct {
 	Datastore datastore.Datastore
 }
 
+type MountSlice []Mount
+
+func (m MountSlice) Len() int {
+	return len(m)
+}
+
+func (m MountSlice) Less(i, j int) bool {
+	return m[i].Prefix.String() > m[j].Prefix.String()
+}
+
+func (m MountSlice) Swap(i, j int) {
+	m[i], m[j] = m[j], m[i]
+}
+
 func New(mounts []Mount) *Datastore {
 	// make a copy so we're sure it doesn't mutate
 	m := make([]Mount, len(mounts))
 	for i, v := range mounts {
 		m[i] = v
 	}
+	sort.Sort(MountSlice(m))
 	return &Datastore{mounts: m}
 }
 

--- a/mount/mount_test.go
+++ b/mount/mount_test.go
@@ -239,3 +239,40 @@ func TestQuerySimple(t *testing.T) {
 		t.Errorf("did not see wanted key %q in %+v", myKey, entries)
 	}
 }
+
+func TestLookupPrio(t *testing.T) {
+	mapds0 := datastore.NewMapDatastore()
+	mapds1 := datastore.NewMapDatastore()
+
+	m := mount.New([]mount.Mount{
+		{Prefix: datastore.NewKey("/"), Datastore: mapds0},
+		{Prefix: datastore.NewKey("/foo"), Datastore: mapds1},
+	})
+
+	m.Put(datastore.NewKey("/foo/bar"), "123")
+	m.Put(datastore.NewKey("/baz"), "234")
+
+	found, err := mapds0.Has(datastore.NewKey("/baz"))
+	if err != nil {
+		t.Fatalf("Has error: %v", err)
+	}
+	if g, e := found, true; g != e {
+		t.Fatalf("wrong value: %v != %v", g, e)
+	}
+
+	found, err = mapds0.Has(datastore.NewKey("/foo/bar"))
+	if err != nil {
+		t.Fatalf("Has error: %v", err)
+	}
+	if g, e := found, false; g != e {
+		t.Fatalf("wrong value: %v != %v", g, e)
+	}
+
+	found, err = mapds1.Has(datastore.NewKey("/bar"))
+	if err != nil {
+		t.Fatalf("Has error: %v", err)
+	}
+	if g, e := found, true; g != e {
+		t.Fatalf("wrong value: %v != %v", g, e)
+	}
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   "license": "MIT",
   "name": "go-datastore",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.2.0"
+  "version": "1.2.1"
 }
 

--- a/syncmount/mount.go
+++ b/syncmount/mount.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 
 	ds "github.com/ipfs/go-datastore"
-	"github.com/ipfs/go-datastore/keytransform"
 	"github.com/ipfs/go-datastore/query"
 )
 
@@ -23,27 +22,13 @@ type Mount struct {
 	Datastore ds.Datastore
 }
 
-type MountSlice []Mount
-
-func (m MountSlice) Len() int {
-	return len(m)
-}
-
-func (m MountSlice) Less(i, j int) bool {
-	return m[i].Prefix.String() > m[j].Prefix.String()
-}
-
-func (m MountSlice) Swap(i, j int) {
-	m[i], m[j] = m[j], m[i]
-}
-
 func New(mounts []Mount) *Datastore {
 	// make a copy so we're sure it doesn't mutate
 	m := make([]Mount, len(mounts))
 	for i, v := range mounts {
 		m[i] = v
 	}
-	sort.Sort(MountSlice(m))
+	sort.Slice(m, func(i, j int) bool { return m[i].Prefix.String() > m[j].Prefix.String() })
 	return &Datastore{mounts: m}
 }
 
@@ -65,6 +50,41 @@ func (d *Datastore) lookup(key ds.Key) (ds.Datastore, ds.Key, ds.Key) {
 		}
 	}
 	return nil, ds.NewKey("/"), key
+}
+
+// lookupAll returns all mounts that might contain keys that are descendant of <key>
+//
+// Matching: /ao/e
+//
+// /          B /ao/e
+// /a/        not matching
+// /ao/       B /e
+// /ao/e/     A /
+// /ao/e/uh/  A /
+// /aoe/      not matching
+func (d *Datastore) lookupAll(key ds.Key) (dst []ds.Datastore, mountpoint, rest []ds.Key) {
+	d.lk.Lock()
+	defer d.lk.Unlock()
+
+	for _, m := range d.mounts {
+		p := m.Prefix.String()
+		if len(p) > 1 {
+			p = p + "/"
+		}
+
+		if strings.HasPrefix(p, key.String()) {
+			dst = append(dst, m.Datastore)
+			mountpoint = append(mountpoint, m.Prefix)
+			rest = append(rest, ds.NewKey("/"))
+		} else if strings.HasPrefix(key.String(), p) {
+			r := strings.TrimPrefix(key.String(), m.Prefix.String())
+
+			dst = append(dst, m.Datastore)
+			mountpoint = append(mountpoint, m.Prefix)
+			rest = append(rest, ds.NewKey(r))
+		}
+	}
+	return dst, mountpoint, rest
 }
 
 func (d *Datastore) Put(key ds.Key, value interface{}) error {
@@ -104,36 +124,65 @@ func (d *Datastore) Query(q query.Query) (query.Results, error) {
 		len(q.Orders) > 0 ||
 		q.Limit > 0 ||
 		q.Offset > 0 {
-		// TODO this is overly simplistic, but the only caller is
-		// `ipfs refs local` for now, and this gets us moving.
+		// TODO this is still overly simplistic, but the only callers are
+		// `ipfs refs local` and ipfs-ds-convert.
 		return nil, errors.New("mount only supports listing all prefixed keys in random order")
 	}
-	key := ds.NewKey(q.Prefix)
-	cds, mount, k := d.lookup(key)
-	if cds == nil {
-		return nil, errors.New("mount only supports listing a mount point")
-	}
-	// TODO support listing cross mount points too
+	prefix := ds.NewKey(q.Prefix)
+	dses, mounts, rests := d.lookupAll(prefix)
 
-	// delegate the query to the mounted datastore, while adjusting
-	// keys in and out
-	q2 := q
-	q2.Prefix = k.String()
-	wrapDS := keytransform.Wrap(cds, &keytransform.Pair{
-		Convert: func(ds.Key) ds.Key {
-			panic("this should never be called")
-		},
-		Invert: func(k ds.Key) ds.Key {
-			return mount.Child(k)
-		},
-	})
+	// current itorator state
+	var res query.Results
+	var dst ds.Datastore
+	var mount ds.Key
+	var rest ds.Key
+	i := 0
 
-	r, err := wrapDS.Query(q2)
-	if err != nil {
-		return nil, err
-	}
-	r = query.ResultsReplaceQuery(r, q)
-	return r, nil
+	return query.ResultsFromIterator(q, query.Iterator{
+		Next: func() (query.Result, bool) {
+			var r query.Result
+			var more bool
+
+			for try := true; try; try = len(dses) > i {
+				if dst == nil {
+					if len(dses) <= i {
+						//This should not happen normally
+						return query.Result{}, false
+					}
+
+					dst = dses[i]
+					mount = mounts[i]
+					rest = rests[i]
+
+					q2 := q
+					q2.Prefix = rest.String()
+					r, err := dst.Query(q2)
+					if err != nil {
+						return query.Result{Error: err}, false
+					}
+					res = r
+				}
+
+				r, more = res.NextSync()
+				if !more {
+					dst = nil
+					i++
+					more = len(dses) > i
+				} else {
+					break
+				}
+			}
+
+			r.Key = mount.Child(ds.RawKey(r.Key)).String()
+			return r, more
+		},
+		Close: func() error {
+			if len(mounts) > i {
+				return res.Close()
+			}
+			return nil
+		},
+	}), nil
 }
 
 func (d *Datastore) IsThreadSafe() {}

--- a/syncmount/mount.go
+++ b/syncmount/mount.go
@@ -5,6 +5,7 @@ package syncmount
 import (
 	"errors"
 	"io"
+	"sort"
 	"strings"
 	"sync"
 
@@ -22,12 +23,27 @@ type Mount struct {
 	Datastore ds.Datastore
 }
 
+type MountSlice []Mount
+
+func (m MountSlice) Len() int {
+	return len(m)
+}
+
+func (m MountSlice) Less(i, j int) bool {
+	return m[i].Prefix.String() > m[j].Prefix.String()
+}
+
+func (m MountSlice) Swap(i, j int) {
+	m[i], m[j] = m[j], m[i]
+}
+
 func New(mounts []Mount) *Datastore {
 	// make a copy so we're sure it doesn't mutate
 	m := make([]Mount, len(mounts))
 	for i, v := range mounts {
 		m[i] = v
 	}
+	sort.Sort(MountSlice(m))
 	return &Datastore{mounts: m}
 }
 

--- a/syncmount/mount_test.go
+++ b/syncmount/mount_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/ipfs/go-datastore"
-	"github.com/ipfs/go-datastore/mount"
 	"github.com/ipfs/go-datastore/query"
+	mount "github.com/ipfs/go-datastore/syncmount"
 )
 
 func TestPutBadNothing(t *testing.T) {
@@ -237,5 +237,42 @@ func TestQuerySimple(t *testing.T) {
 	}
 	if !seen {
 		t.Errorf("did not see wanted key %q in %+v", myKey, entries)
+	}
+}
+
+func TestLookupPrio(t *testing.T) {
+	mapds0 := datastore.NewMapDatastore()
+	mapds1 := datastore.NewMapDatastore()
+
+	m := mount.New([]mount.Mount{
+		{Prefix: datastore.NewKey("/"), Datastore: mapds0},
+		{Prefix: datastore.NewKey("/foo"), Datastore: mapds1},
+	})
+
+	m.Put(datastore.NewKey("/foo/bar"), "123")
+	m.Put(datastore.NewKey("/baz"), "234")
+
+	found, err := mapds0.Has(datastore.NewKey("/baz"))
+	if err != nil {
+		t.Fatalf("Has error: %v", err)
+	}
+	if g, e := found, true; g != e {
+		t.Fatalf("wrong value: %v != %v", g, e)
+	}
+
+	found, err = mapds0.Has(datastore.NewKey("/foo/bar"))
+	if err != nil {
+		t.Fatalf("Has error: %v", err)
+	}
+	if g, e := found, false; g != e {
+		t.Fatalf("wrong value: %v != %v", g, e)
+	}
+
+	found, err = mapds1.Has(datastore.NewKey("/bar"))
+	if err != nil {
+		t.Fatalf("Has error: %v", err)
+	}
+	if g, e := found, true; g != e {
+		t.Fatalf("wrong value: %v != %v", g, e)
 	}
 }


### PR DESCRIPTION
* mountds.Query now works across datastores
* Mounts are sorted to mitigate `lookup` dependency on ordered keys
* `syncmount` tests now actually test syncmount DS
