### PR TITLE
Fix subquery closing in mount, improve namespace.Query

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.2.1: QmSiN66ybp5udnQnvhb6euiWiiQWdGvwMhAWa95cC1DTCV
+1.2.2: QmVSase1JP7cq9QkPT46oNwdp9pT6kBkG3oqS14y3QcZjG

--- a/mount/mount_test.go
+++ b/mount/mount_test.go
@@ -238,6 +238,11 @@ func TestQuerySimple(t *testing.T) {
 	if !seen {
 		t.Errorf("did not see wanted key %q in %+v", myKey, entries)
 	}
+
+	err = res.Close()
+	if err != nil {
+		t.Errorf("result.Close failed %d", err)
+	}
 }
 
 func TestQueryCross(t *testing.T) {
@@ -291,6 +296,11 @@ func TestQueryCross(t *testing.T) {
 
 	if seen != 4 {
 		t.Errorf("expected to see 3 values, saw %d", seen)
+	}
+
+	err = res.Close()
+	if err != nil {
+		t.Errorf("result.Close failed %d", err)
 	}
 }
 

--- a/namespace/namespace.go
+++ b/namespace/namespace.go
@@ -55,7 +55,9 @@ type datastore struct {
 }
 
 // Query implements Query, inverting keys on the way back out.
+// This function assumes that child datastore.Query returns ordered results
 func (d *datastore) Query(q dsq.Query) (dsq.Results, error) {
+	q.Prefix = d.prefix.Child(ds.NewKey(q.Prefix)).String()
 	qr, err := d.raw.Query(q)
 	if err != nil {
 		return nil, err
@@ -73,7 +75,7 @@ func (d *datastore) Query(q dsq.Query) (dsq.Results, error) {
 				}
 				k := ds.RawKey(r.Entry.Key)
 				if !d.prefix.IsAncestorOf(k) {
-					continue
+					return dsq.Result{}, false
 				}
 
 				r.Entry.Key = d.Datastore.InvertKey(k).String()

--- a/namespace/namespace_test.go
+++ b/namespace/namespace_test.go
@@ -100,13 +100,14 @@ func (ks *DSSuite) TestQuery(c *C) {
 	c.Check(err, Equals, nil)
 
 	expect := []dsq.Entry{
-		{Key:"/bar", Value: []byte("/foo/bar")},
-		{Key:"/bar/baz", Value: []byte("/foo/bar/baz")},
-		{Key:"/baz/abc", Value: []byte("/foo/baz/abc")},
+		{Key: "/bar", Value: []byte("/foo/bar")},
+		{Key: "/bar/baz", Value: []byte("/foo/bar/baz")},
+		{Key: "/baz/abc", Value: []byte("/foo/baz/abc")},
 	}
 
 	results, err := qres.Rest()
 	c.Check(err, Equals, nil)
+	sort.Slice(results, func(i, j int) bool { return results[i].Key < results[j].Key })
 
 	for i, ent := range results {
 		c.Check(ent.Key, Equals, expect[i].Key)
@@ -118,16 +119,17 @@ func (ks *DSSuite) TestQuery(c *C) {
 	err = qres.Close()
 	c.Check(err, Equals, nil)
 
-	qres, err = nsds.Query(dsq.Query{Prefix:"bar"})
+	qres, err = nsds.Query(dsq.Query{Prefix: "bar"})
 	c.Check(err, Equals, nil)
 
 	expect = []dsq.Entry{
-		{Key:"/bar", Value: []byte("/foo/bar")},
-		{Key:"/bar/baz", Value: []byte("/foo/bar/baz")},
+		{Key: "/bar", Value: []byte("/foo/bar")},
+		{Key: "/bar/baz", Value: []byte("/foo/bar/baz")},
 	}
 
 	results, err = qres.Rest()
 	c.Check(err, Equals, nil)
+	sort.Slice(results, func(i, j int) bool { return results[i].Key < results[j].Key })
 
 	for i, ent := range results {
 		c.Check(ent.Key, Equals, expect[i].Key)

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   "license": "MIT",
   "name": "go-datastore",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.2.1"
+  "version": "1.2.2"
 }
 

--- a/syncmount/mount_test.go
+++ b/syncmount/mount_test.go
@@ -1,6 +1,7 @@
 package syncmount_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/ipfs/go-datastore"
@@ -338,5 +339,35 @@ func TestLookupPrio(t *testing.T) {
 	}
 	if g, e := found, true; g != e {
 		t.Fatalf("wrong value: %v != %v", g, e)
+	}
+}
+
+type errQueryDS struct {
+	datastore.NullDatastore
+}
+
+func (d *errQueryDS) Query(q query.Query) (query.Results, error) {
+	return nil, errors.New("test error")
+}
+
+func TestErrQueryClose(t *testing.T) {
+	eqds := &errQueryDS{}
+	mds := datastore.NewMapDatastore()
+
+	m := mount.New([]mount.Mount{
+		{Prefix: datastore.NewKey("/"), Datastore: mds},
+		{Prefix: datastore.NewKey("/foo"), Datastore: eqds},
+	})
+
+	m.Put(datastore.NewKey("/baz"), "123")
+
+	qr, err := m.Query(query.Query{})
+	if err != nil {
+		t.Fatalf("Query error: %v", err)
+	}
+
+	e, ok := qr.NextSync()
+	if ok != false || e.Error == nil {
+		t.Errorf("Query was ok or q.Error was nil")
 	}
 }

--- a/syncmount/mount_test.go
+++ b/syncmount/mount_test.go
@@ -238,6 +238,11 @@ func TestQuerySimple(t *testing.T) {
 	if !seen {
 		t.Errorf("did not see wanted key %q in %+v", myKey, entries)
 	}
+
+	err = res.Close()
+	if err != nil {
+		t.Errorf("result.Close failed %d", err)
+	}
 }
 
 func TestQueryCross(t *testing.T) {
@@ -291,6 +296,11 @@ func TestQueryCross(t *testing.T) {
 
 	if seen != 4 {
 		t.Errorf("expected to see 3 values, saw %d", seen)
+	}
+
+	err = res.Close()
+	if err != nil {
+		t.Errorf("result.Close failed %d", err)
 	}
 }
 


### PR DESCRIPTION
Tested on go-ipfs, this seems to fix related issues.