### PR TITLE
Implement json.Marshaler and json.Unmarshaler on datastore.Key

### DIFF
--- a/key.go
+++ b/key.go
@@ -1,6 +1,7 @@
 package datastore
 
 import (
+	"errors"
 	"path"
 	"strings"
 
@@ -230,6 +231,23 @@ func (k Key) IsDescendantOf(other Key) bool {
 // IsTopLevel returns whether this key has only one namespace.
 func (k Key) IsTopLevel() bool {
 	return len(k.List()) == 1
+}
+
+// MarshalJSON implements the json.Marshaler interface,
+// keys are represented as JSON strings
+func (k Key) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + k.String() + `"`), nil
+}
+
+// MarshalJSON implements the json.Unmarshaler interface,
+// keys will parse any value specified as a key to a string
+func (k *Key) UnmarshalJSON(data []byte) error {
+	if len(data) < 2 {
+		k.Clean()
+		return errors.New("too short to unmarshal key to json string")
+	}
+	*k = NewKey(string(data[1 : len(data)-1]))
+	return nil
 }
 
 // RandomKey returns a randomly (uuid) generated key.

--- a/key.go
+++ b/key.go
@@ -1,7 +1,7 @@
 package datastore
 
 import (
-	"errors"
+	"encoding/json"
 	"path"
 	"strings"
 
@@ -236,17 +236,17 @@ func (k Key) IsTopLevel() bool {
 // MarshalJSON implements the json.Marshaler interface,
 // keys are represented as JSON strings
 func (k Key) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + k.String() + `"`), nil
+	return json.Marshal(k.String())
 }
 
 // MarshalJSON implements the json.Unmarshaler interface,
 // keys will parse any value specified as a key to a string
 func (k *Key) UnmarshalJSON(data []byte) error {
-	if len(data) < 2 {
-		k.Clean()
-		return errors.New("too short to unmarshal key to json string")
+	var key string
+	if err := json.Unmarshal(data, &key); err != nil {
+		return err
 	}
-	*k = NewKey(string(data[1 : len(data)-1]))
+	*k = NewKey(key)
 	return nil
 }
 

--- a/key_test.go
+++ b/key_test.go
@@ -163,6 +163,7 @@ func TestKeyMarshalJSON(t *testing.T) {
 		err  string
 	}{
 		{NewKey("/a/b/c"), []byte("\"/a/b/c\""), ""},
+		{NewKey("/shouldescapekey\"/with/quote"), []byte("\"/shouldescapekey\"/with/quote\""), ""},
 	}
 
 	for i, c := range cases {
@@ -172,6 +173,16 @@ func TestKeyMarshalJSON(t *testing.T) {
 		}
 		if !bytes.Equal(c.data, out) {
 			t.Errorf("case %d value mismatch: expected: %s, got: %s", i, string(c.data), string(out))
+		}
+
+		if c.err == "" {
+			key := Key{}
+			if err := key.UnmarshalJSON(out); err != nil {
+				t.Errorf("case %d error parsing key from json output: %s", i, err.Error())
+			}
+			if !c.key.Equal(key) {
+				t.Errorf("case %d parsed key from json output mismatch. expected: %s, got: %s", i, c.key.String(), key.String())
+			}
 		}
 	}
 }

--- a/key_test.go
+++ b/key_test.go
@@ -163,7 +163,7 @@ func TestKeyMarshalJSON(t *testing.T) {
 		err  string
 	}{
 		{NewKey("/a/b/c"), []byte("\"/a/b/c\""), ""},
-		{NewKey("/shouldescapekey\"/with/quote"), []byte("\"/shouldescapekey\"/with/quote\""), ""},
+		{NewKey("/shouldescapekey\"/with/quote"), []byte("\"/shouldescapekey\\\"/with/quote\""), ""},
 	}
 
 	for i, c := range cases {
@@ -194,9 +194,9 @@ func TestKeyUnmarshalJSON(t *testing.T) {
 		err  string
 	}{
 		{[]byte("\"/a/b/c\""), NewKey("/a/b/c"), ""},
-		{[]byte{}, NewKey("/"), "too short to unmarshal key to json string"},
-		{[]byte{'"'}, NewKey("/"), "too short to unmarshal key to json string"},
-		{[]byte(`""`), NewKey("/"), ""},
+		{[]byte{}, Key{}, "unexpected end of JSON input"},
+		{[]byte{'"'}, Key{}, "unexpected end of JSON input"},
+		{[]byte(`""`), NewKey(""), ""},
 	}
 
 	for i, c := range cases {

--- a/key_test.go
+++ b/key_test.go
@@ -194,8 +194,8 @@ func TestKeyUnmarshalJSON(t *testing.T) {
 		err  string
 	}{
 		{[]byte("\"/a/b/c\""), NewKey("/a/b/c"), ""},
-		{[]byte{}, NewKey("/"), "too short to unmarshal json string"},
-		{[]byte{'"'}, NewKey("/"), "too short to unmarshal json string"},
+		{[]byte{}, NewKey("/"), "too short to unmarshal key to json string"},
+		{[]byte{'"'}, NewKey("/"), "too short to unmarshal key to json string"},
 		{[]byte(`""`), NewKey("/"), ""},
 	}
 

--- a/key_test.go
+++ b/key_test.go
@@ -155,3 +155,48 @@ func (ks *KeySuite) TestLess(c *C) {
 	checkLess("/a/b/c/d/e/f/g/h", "/b")
 	checkLess("/", "/a")
 }
+
+func TestKeyMarshalJSON(t *testing.T) {
+	cases := []struct {
+		key  Key
+		data []byte
+		err  string
+	}{
+		{NewKey("/a/b/c"), []byte("\"/a/b/c\""), ""},
+	}
+
+	for i, c := range cases {
+		out, err := c.key.MarshalJSON()
+		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
+			t.Errorf("case %d marshal error mismatch: expected: %s, got: %s", i, c.err, err)
+		}
+		if !bytes.Equal(c.data, out) {
+			t.Errorf("case %d value mismatch: expected: %s, got: %s", i, string(c.data), string(out))
+		}
+	}
+}
+
+func TestKeyUnmarshalJSON(t *testing.T) {
+	cases := []struct {
+		data []byte
+		key  Key
+		err  string
+	}{
+		{[]byte("\"/a/b/c\""), NewKey("/a/b/c"), ""},
+		{[]byte{}, NewKey("/"), "too short to unmarshal json string"},
+		{[]byte{'"'}, NewKey("/"), "too short to unmarshal json string"},
+		{[]byte(`""`), NewKey("/"), ""},
+	}
+
+	for i, c := range cases {
+		key := Key{}
+		err := key.UnmarshalJSON(c.data)
+		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
+			t.Errorf("case %d marshal error mismatch: expected: %s, got: %s", i, c.err, err)
+		}
+
+		if !key.Equal(c.key) {
+			t.Errorf("case %d key mismatch: expected: %s, got: %s", i, c.key, key)
+		}
+	}
+}


### PR DESCRIPTION
Not sure weather this will be acceptable, but I'd love to be able to marshal / unmarshal datastore.Key values to and from JSON strings for clearer struct definitions that work with `datastore.Key`'s. We're doing all kinds of off-label stuff with the datastore interface, and this would be a huge help, I could also see potential upsides in IPLD land.

That being said, I can understand why marshaling to and from datastore.Key's may _not_ be a desired behavior, and would be more than happy to close this PR unmerged in that case.

Assuming you're ok with the idea of keys going to and from JSON, there are three options to get `datastore.Key`'s to do JSON:

1. **`type Key struct{ string }` -> `type Key string`**
 _I'm guessing you have a good reason for key's being a struct type, so leaving that alone_
2. **`import encoding/json`, implement `json.Un/Marshaler` with string types** 
_ew gross_
3. **implement a bare bones `json.Un/Marshaler`**
  _what this pr proposes_

I think the third option makes the most sense, it has the downside that if people put horribly malformed stuff in their json it'll just coerce that field to a string and not complain, which might be ugly, but seems both unlikely and not unlike the behavior of other higher-level languages. The upside is no added dependencies for such a foundational package.

