### PR TITLE
Add Size() method to datastores

### DIFF
--- a/basic_ds.go
+++ b/basic_ds.go
@@ -168,9 +168,8 @@ func (d *LogDatastore) Delete(key Key) (err error) {
 
 // DiskUsage implements the PersistentDatastore interface.
 func (d *LogDatastore) DiskUsage() (uint64, error) {
-	du, err := DiskUsage(d.child)
-	log.Printf("%s: DiskUsage: %d\n", d.Name, du)
-	return du, err
+	log.Printf("%s: DiskUsage\n", d.Name)
+	return DiskUsage(d.child)
 }
 
 // Query implements Datastore.Query

--- a/basic_ds.go
+++ b/basic_ds.go
@@ -166,6 +166,13 @@ func (d *LogDatastore) Delete(key Key) (err error) {
 	return d.child.Delete(key)
 }
 
+// DiskUsage implements the PersistentDatastore interface.
+func (d *LogDatastore) DiskUsage() (uint64, error) {
+	du, err := DiskUsage(d.child)
+	log.Printf("%s: DiskUsage: %d\n", d.Name, du)
+	return du, err
+}
+
 // Query implements Datastore.Query
 func (d *LogDatastore) Query(q dsq.Query) (dsq.Results, error) {
 	log.Printf("%s: Query\n", d.Name)

--- a/callback/callback.go
+++ b/callback/callback.go
@@ -40,3 +40,9 @@ func (c *Datastore) Query(q dsq.Query) (dsq.Results, error) {
 	c.F()
 	return c.D.Query(q)
 }
+
+// DiskUsage implements the PersistentDatastore interface.
+func (c *Datastore) DiskUsage() (uint64, error) {
+	c.F()
+	return ds.DiskUsage(c.D)
+}

--- a/coalesce/coalesce.go
+++ b/coalesce/coalesce.go
@@ -138,3 +138,8 @@ func (d *datastore) Close() error {
 	}
 	return nil
 }
+
+// DiskUsage implements the PersistentDatastore interface.
+func (d *datastore) DiskUsage() (uint64, error) {
+	return ds.DiskUsage(d.child)
+}

--- a/datastore.go
+++ b/datastore.go
@@ -95,7 +95,7 @@ type CheckedDatastore interface {
 
 // CheckedDatastore is an interface that should be implemented by datastores
 // which want to provide a mechanism to check data integrity and/or
-// error correction
+// error correction.
 type ScrubbedDatastore interface {
 	Datastore
 
@@ -103,11 +103,31 @@ type ScrubbedDatastore interface {
 }
 
 // GCDatastore is an interface that should be implemented by datastores which
-// don't free disk space by just removing data from them
+// don't free disk space by just removing data from them.
 type GCDatastore interface {
 	Datastore
 
 	CollectGarbage() error
+}
+
+// PersistentDatastore is an interface that should be implemented by datastores
+// which can report disk usage.
+type PersistentDatastore interface {
+	Datastore
+
+	// DiskUsage returns the space used by a datastore, in bytes.
+	DiskUsage() (uint64, error)
+}
+
+// DiskUsage checks if a Datastore is a
+// PersistentDatastore and returns its DiskUsage(),
+// otherwise returns 0.
+func DiskUsage(d Datastore) (uint64, error) {
+	persDs, ok := d.(PersistentDatastore)
+	if !ok {
+		return 0, nil
+	}
+	return persDs.DiskUsage()
 }
 
 // Errors

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -1,5 +1,5 @@
 // Package fs is a simple Datastore implementation that stores keys
-// are directories and files, mirroring the key. That is, the key
+// as directories and files, mirroring the key. That is, the key
 // "/foo/bar" is stored as file "PATH/foo/bar/.dsobject".
 //
 // This means key some segments will not work. For example, the
@@ -20,6 +20,7 @@ package fs
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -156,4 +157,20 @@ func (d *Datastore) Close() error {
 
 func (d *Datastore) Batch() (ds.Batch, error) {
 	return ds.NewBasicBatch(d), nil
+}
+
+// DiskUsage returns the disk size used by the datastore in bytes.
+func (d *Datastore) DiskUsage() (uint64, error) {
+	var du uint64
+	err := filepath.Walk(d.path, func(p string, f os.FileInfo, err error) error {
+		if err != nil {
+			log.Println(err)
+			return err
+		}
+		if f != nil {
+			du += uint64(f.Size())
+		}
+		return nil
+	})
+	return du, err
 }

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -87,6 +87,30 @@ func (ks *DSSuite) TestBasic(c *C) {
 	}
 }
 
+func (ks *DSSuite) TestDiskUsage(c *C) {
+	keys := strsToKeys([]string{
+		"foo",
+		"foo/bar",
+		"foo/bar/baz",
+		"foo/barb",
+		"foo/bar/bazb",
+		"foo/bar/baz/barb",
+	})
+
+	for _, k := range keys {
+		err := ks.ds.Put(k, []byte(k.String()))
+		c.Check(err, Equals, nil)
+	}
+
+	if ps, ok := ks.ds.(ds.PersistentDatastore); ok {
+		if s, err := ps.DiskUsage(); s <= 100 || err != nil {
+			c.Error("unexpected size is: ", s)
+		}
+	} else {
+		c.Error("should implement PersistentDatastore")
+	}
+}
+
 func strsToKeys(strs []string) []ds.Key {
 	keys := make([]ds.Key, len(strs))
 	for i, s := range strs {

--- a/keytransform/keytransform.go
+++ b/keytransform/keytransform.go
@@ -84,6 +84,11 @@ func (d *ktds) Close() error {
 	return nil
 }
 
+// DiskUsage implements the PersistentDatastore interface.
+func (d *ktds) DiskUsage() (uint64, error) {
+	return ds.DiskUsage(d.child)
+}
+
 func (d *ktds) Batch() (ds.Batch, error) {
 	bds, ok := d.child.(ds.Batching)
 	if !ok {

--- a/mount/mount.go
+++ b/mount/mount.go
@@ -194,6 +194,19 @@ func (d *Datastore) Close() error {
 	return nil
 }
 
+// DiskUsage implements the PersistentDatastore interface.
+func (d *Datastore) DiskUsage() (uint64, error) {
+	var duTotal uint64 = 0
+	for _, d := range d.mounts {
+		du, err := datastore.DiskUsage(d.Datastore)
+		duTotal += du
+		if err != nil {
+			return duTotal, err
+		}
+	}
+	return duTotal, nil
+}
+
 type mountBatch struct {
 	mounts map[string]datastore.Batch
 

--- a/panic/panic.go
+++ b/panic/panic.go
@@ -79,6 +79,15 @@ func (d *datastore) Close() error {
 	return nil
 }
 
+// DiskUsage implements the PersistentDatastore interface.
+func (d *datastore) DiskUsage() (uint64, error) {
+	du, err := ds.DiskUsage(d.child)
+	if err != nil {
+		panic(err)
+	}
+	return du, nil
+}
+
 func (d *datastore) Batch() (ds.Batch, error) {
 	b, err := d.child.(ds.Batching).Batch()
 	if err != nil {

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -92,6 +92,13 @@ func (d *MutexDatastore) Close() error {
 	return nil
 }
 
+// DiskUsage implements the PersistentDatastore interface.
+func (d *MutexDatastore) DiskUsage() (uint64, error) {
+	d.RLock()
+	defer d.RUnlock()
+	return ds.DiskUsage(d.child)
+}
+
 type syncBatch struct {
 	batch ds.Batch
 	mds   *MutexDatastore

--- a/syncmount/mount.go
+++ b/syncmount/mount.go
@@ -203,6 +203,20 @@ func (d *Datastore) Close() error {
 	return nil
 }
 
+// DiskUsage returns the sum of DiskUsages for the mounted datastores.
+// Non PersistentDatastores will not be accounted.
+func (d *Datastore) DiskUsage() (uint64, error) {
+	var duTotal uint64 = 0
+	for _, d := range d.mounts {
+		du, err := ds.DiskUsage(d.Datastore)
+		duTotal += du
+		if err != nil {
+			return duTotal, err
+		}
+	}
+	return duTotal, nil
+}
+
 type mountBatch struct {
 	mounts map[string]ds.Batch
 	lk     sync.Mutex

--- a/tiered/tiered_test.go
+++ b/tiered/tiered_test.go
@@ -64,6 +64,19 @@ func TestTiered(t *testing.T) {
 	testHas(t, td, ds.NewKey("foo"), "bar2")
 }
 
+func TestTieredDiskUsage(t *testing.T) {
+	d1 := ds.NewMapDatastore()
+	d2 := ds.NewMapDatastore()
+	d3 := ds.NewMapDatastore()
+	d4 := ds.NewMapDatastore()
+
+	td := New(d1, d2, d3, d4)
+	td.Put(ds.NewKey("foo"), "bar")
+	if du, err := td.DiskUsage(); du != 0 || err != nil {
+		t.Error("tiered datastore size should be 0")
+	}
+}
+
 func TestQueryCallsLast(t *testing.T) {
 	var d1n, d2n, d3n int
 	d1 := dscb.Wrap(ds.NewMapDatastore(), func() { d1n++ })

--- a/timecache/timecache.go
+++ b/timecache/timecache.go
@@ -102,3 +102,8 @@ func (d *datastore) Close() error {
 	}
 	return nil
 }
+
+// DiskUsage implements the PersistentDatastore interface.
+func (d *datastore) DiskUsage() (uint64, error) {
+	return ds.DiskUsage(d.cache)
+}


### PR DESCRIPTION
The each implementation of a datastore should decide on their size
is measured and how accurate the result is.

i.e. Some datastores may consider Size as the number of entries,
others as the disk space they use etc. Some implementations may
opt to improve the performance of the operation by caching or
by reducing the accuracy of the calculation.

Related: https://github.com/ipfs/go-ipfs/pull/4550