### PR TITLE
Import ds-help methods from go-ipfs/thirdparty

### DIFF
--- a/ds_help.go
+++ b/ds_help.go
@@ -1,0 +1,29 @@
+package datastore
+
+import (
+	cid "github.com/ipfs/go-cid"
+	"github.com/whyrusleeping/base32"
+)
+
+func NewKeyFromBinary(rawKey []byte) Key {
+	buf := make([]byte, 1+base32.RawStdEncoding.EncodedLen(len(rawKey)))
+	buf[0] = '/'
+	base32.RawStdEncoding.Encode(buf[1:], rawKey)
+	return RawKey(string(buf))
+}
+
+func BinaryFromDsKey(k Key) ([]byte, error) {
+	return base32.RawStdEncoding.DecodeString(k.String()[1:])
+}
+
+func CidToDsKey(k *cid.Cid) Key {
+	return NewKeyFromBinary(k.Bytes())
+}
+
+func DsKeyToCid(dsKey Key) (*cid.Cid, error) {
+	kb, err := BinaryFromDsKey(dsKey)
+	if err != nil {
+		return nil, err
+	}
+	return cid.Cast(kb)
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,18 @@
       "hash": "QmYBJ8BXPDTMnzLFdv4rS5kbR1fUFASDVDpK7ZbeWMx6hq",
       "name": "go-check",
       "version": "1.0.0"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "QmcZfnkapfECQGcLZaf9B79NRg7cRa9EnZh4LSbkCzwNvY",
+      "name": "go-cid",
+      "version": "0.7.20"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "QmfVj3x4D6Jkq9SEoi5n2NmoUomLwoeiwnYz2KQa15wRw6",
+      "name": "base32",
+      "version": "0.0.2"
     }
   ],
   "gxVersion": "0.7.0",


### PR DESCRIPTION
There is a TODO: put this code into the go-datastore itself.

I will PR to ipfs after this is merged and a new gx published.