### PR TITLE
Add TTL and Transactional interfaces

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-3.0.0: QmVG5gxteQNEMhrS8prJSmU2C9rebtFuTd3SYZ5kE3YZ5k
+3.1.0: QmSpg1CvpXQQow5ernt1gNBXaXV6yxyNqi7XoeerWfzB5w

--- a/datastore.go
+++ b/datastore.go
@@ -140,12 +140,24 @@ type TTLDatastore interface {
 	SetTTL(key Key, ttl time.Duration) error
 }
 
-// Txn is an interface for transactions that can be committed or rolled back.
+// Txn is an interface for transactions that can be committed or discarded.
 type Txn interface {
+	// Txn extends the Datastore type. Txns allow users to batch queries and
+	// mutations to the Datastore into atomic groups, or transactions. Actions
+	// performed on a transaction will not take hold until a successful call to
+	// Commit has been made. Likewise, transactions can be aborted by calling
+	// Discard before a successful Commit has been made.
 	Datastore
 
+	// Commit finalizes a transaction, attempting to commit it to the Datastore.
+	// May return an error if the transaction has gone stale. The presence of an
+	// error is an indication that the data was not committed to the Datastore.
 	Commit() error
-	Rollback()
+	// Discard throws away changes recorded in a transaction without committing
+	// them to the underlying Datastore. Any calls made to Discard after Commit
+	// has been successfully called will have no effect on the transaction and
+	// state of the Datastore, making it safe to defer.
+	Discard()
 }
 
 // TxDatastore is an interface that should be implemented by datastores that

--- a/datastore.go
+++ b/datastore.go
@@ -136,7 +136,7 @@ func DiskUsage(d Datastore) (uint64, error) {
 type TTLDatastore interface {
 	Datastore
 
-	PutWithTTL(key Key, value interface{}, ttl time.Duration) error
+	PutWithTTL(key Key, value []byte, ttl time.Duration) error
 	SetTTL(key Key, ttl time.Duration) error
 }
 

--- a/datastore.go
+++ b/datastore.go
@@ -142,12 +142,16 @@ type TTLDatastore interface {
 
 // Txn is an interface for transactions that can be committed or discarded.
 type Txn interface {
-	// Txn extends the Datastore type. Txns allow users to batch queries and
-	// mutations to the Datastore into atomic groups, or transactions. Actions
-	// performed on a transaction will not take hold until a successful call to
-	// Commit has been made. Likewise, transactions can be aborted by calling
-	// Discard before a successful Commit has been made.
-	Datastore
+	// Txn has the same capabilities as Datastore. Txns allow users to batch
+	// queries and mutations to the Datastore into atomic groups, or transactions.
+	// Actions performed on a transaction will not take hold until a successful
+	// call to Commit has been made. Likewise, transactions can be aborted by
+	// calling Discard before a successful Commit has been made.
+	Put(key Key, value interface{}) error
+	Get(key Key) (value interface{}, err error)
+	Has(key Key) (exists bool, err error)
+	Delete(key Key) error
+	Query(q query.Query) (query.Results, error)
 
 	// Commit finalizes a transaction, attempting to commit it to the Datastore.
 	// May return an error if the transaction has gone stale. The presence of an
@@ -160,7 +164,7 @@ type Txn interface {
 	Discard()
 }
 
-// TxDatastore is an interface that should be implemented by datastores that
+// TxnDatastore is an interface that should be implemented by datastores that
 // support transactions.
 type TxnDatastore interface {
 	Datastore

--- a/datastore.go
+++ b/datastore.go
@@ -2,6 +2,7 @@ package datastore
 
 import (
 	"errors"
+	"time"
 
 	query "github.com/ipfs/go-datastore/query"
 )
@@ -128,6 +129,31 @@ func DiskUsage(d Datastore) (uint64, error) {
 		return 0, nil
 	}
 	return persDs.DiskUsage()
+}
+
+// TTLDatastore is an interface that should be implemented by datastores that
+// support expiring entries.
+type TTLDatastore interface {
+	Datastore
+
+	PutWithTTL(key Key, value interface{}, ttl time.Duration) error
+	SetTTL(key Key, ttl time.Duration) error
+}
+
+// Txn is an interface for transactions that can be committed or rolled back.
+type Txn interface {
+	Datastore
+
+	Commit() error
+	Rollback()
+}
+
+// TxDatastore is an interface that should be implemented by datastores that
+// support transactions.
+type TxDatastore interface {
+	Datastore
+
+	NewTransaction() Txn
 }
 
 // Errors

--- a/datastore.go
+++ b/datastore.go
@@ -140,13 +140,12 @@ type TTLDatastore interface {
 	SetTTL(key Key, ttl time.Duration) error
 }
 
-// Txn is an interface for transactions that can be committed or discarded.
+// Txn extends the Datastore type. Txns allow users to batch queries and
+// mutations to the Datastore into atomic groups, or transactions. Actions
+// performed on a transaction will not take hold until a successful call to
+// Commit has been made. Likewise, transactions can be aborted by calling
+// Discard before a successful Commit has been made.
 type Txn interface {
-	// Txn extends the Datastore type. Txns allow users to batch queries and
-	// mutations to the Datastore into atomic groups, or transactions. Actions
-	// performed on a transaction will not take hold until a successful call to
-	// Commit has been made. Likewise, transactions can be aborted by calling
-	// Discard before a successful Commit has been made.
 	Datastore
 
 	// Commit finalizes a transaction, attempting to commit it to the Datastore.
@@ -160,7 +159,7 @@ type Txn interface {
 	Discard()
 }
 
-// TxDatastore is an interface that should be implemented by datastores that
+// TxnDatastore is an interface that should be implemented by datastores that
 // support transactions.
 type TxnDatastore interface {
 	Datastore

--- a/datastore.go
+++ b/datastore.go
@@ -153,7 +153,7 @@ type Txn interface {
 type TxDatastore interface {
 	Datastore
 
-	NewTransaction() Txn
+	NewTransaction(readOnly bool) Txn
 }
 
 // Errors

--- a/datastore.go
+++ b/datastore.go
@@ -150,7 +150,7 @@ type Txn interface {
 
 // TxDatastore is an interface that should be implemented by datastores that
 // support transactions.
-type TxDatastore interface {
+type TxnDatastore interface {
 	Datastore
 
 	NewTransaction(readOnly bool) Txn

--- a/datastore.go
+++ b/datastore.go
@@ -142,16 +142,12 @@ type TTLDatastore interface {
 
 // Txn is an interface for transactions that can be committed or discarded.
 type Txn interface {
-	// Txn has the same capabilities as Datastore. Txns allow users to batch
-	// queries and mutations to the Datastore into atomic groups, or transactions.
-	// Actions performed on a transaction will not take hold until a successful
-	// call to Commit has been made. Likewise, transactions can be aborted by
-	// calling Discard before a successful Commit has been made.
-	Put(key Key, value interface{}) error
-	Get(key Key) (value interface{}, err error)
-	Has(key Key) (exists bool, err error)
-	Delete(key Key) error
-	Query(q query.Query) (query.Results, error)
+	// Txn extends the Datastore type. Txns allow users to batch queries and
+	// mutations to the Datastore into atomic groups, or transactions. Actions
+	// performed on a transaction will not take hold until a successful call to
+	// Commit has been made. Likewise, transactions can be aborted by calling
+	// Discard before a successful Commit has been made.
+	Datastore
 
 	// Commit finalizes a transaction, attempting to commit it to the Datastore.
 	// May return an error if the transaction has gone stale. The presence of an
@@ -164,7 +160,7 @@ type Txn interface {
 	Discard()
 }
 
-// TxnDatastore is an interface that should be implemented by datastores that
+// TxDatastore is an interface that should be implemented by datastores that
 // support transactions.
 type TxnDatastore interface {
 	Datastore

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
   "license": "MIT",
   "name": "go-datastore",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "3.0.0"
+  "version": "3.1.0"
 }
 


### PR DESCRIPTION
adds two `Datastore` superclasses, `TTLDatastore` and `TxDatastore`. together, these give us pretty complete access to datastores such as badger.

closes #87 and simplifies a slew of other issues as well.