### PR TITLE
Add support for querying entry expiration

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-3.1.0: QmSpg1CvpXQQow5ernt1gNBXaXV6yxyNqi7XoeerWfzB5w
+3.2.0: QmUyz7JTJzgegC6tiJrfby3mPhzcdswVtG4x58TQ6pq8jV

--- a/datastore.go
+++ b/datastore.go
@@ -138,6 +138,7 @@ type TTLDatastore interface {
 
 	PutWithTTL(key Key, value []byte, ttl time.Duration) error
 	SetTTL(key Key, ttl time.Duration) error
+	GetExpiration(key Key) (time.Time, error)
 }
 
 // Txn extends the Datastore type. Txns allow users to batch queries and

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
   "license": "MIT",
   "name": "go-datastore",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "3.1.0"
+  "version": "3.2.0"
 }
 

--- a/query/query.go
+++ b/query/query.go
@@ -1,6 +1,8 @@
 package query
 
 import (
+	"time"
+
 	goprocess "github.com/jbenet/goprocess"
 )
 
@@ -56,18 +58,20 @@ cost of the layer of abstraction.
 
 */
 type Query struct {
-	Prefix   string   // namespaces the query to results whose keys have Prefix
-	Filters  []Filter // filter results. apply sequentially
-	Orders   []Order  // order results. apply sequentially
-	Limit    int      // maximum number of results
-	Offset   int      // skip given number of results
-	KeysOnly bool     // return only keys.
+	Prefix            string   // namespaces the query to results whose keys have Prefix
+	Filters           []Filter // filter results. apply sequentially
+	Orders            []Order  // order results. apply sequentially
+	Limit             int      // maximum number of results
+	Offset            int      // skip given number of results
+	KeysOnly          bool     // return only keys.
+	ReturnExpirations bool     // return expirations (see TTLDatastore)
 }
 
 // Entry is a query result entry.
 type Entry struct {
-	Key   string // cant be ds.Key because circular imports ...!!!
-	Value []byte // Will be nil if KeysOnly has been passed.
+	Key        string    // cant be ds.Key because circular imports ...!!!
+	Value      []byte    // Will be nil if KeysOnly has been passed.
+	Expiration time.Time // Entry expiration timestamp if requested and supported (see TTLDatastore).
 }
 
 // Result is a special entry that includes an error, so that the client


### PR DESCRIPTION
Adds the following:

* `GetExpiration` function on `TTLDatastore`.
* `ReturnExpirations` field on query options.
* `Expiration` on query result object.

The only implementation of the affected interface is go-ds-badger, and the PR to implement this functionality is here: https://github.com/ipfs/go-ds-badger/pull/32