### PR TITLE
query: make datastore ordering act like a user would expect

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-3.4.1: Qmf4xQhNomPNhrtZc67qSnfJSjxjXs9LWvknJtSXwimPrM
+3.5.0: QmPGYyi1DtuWyUkG3PtvLz1xb4ScjnUvwJMCoX3cxeyxNr

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
   "license": "MIT",
   "name": "go-datastore",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "3.4.1"
+  "version": "3.5.0"
 }
 

--- a/query/order.go
+++ b/query/order.go
@@ -1,66 +1,48 @@
 package query
 
 import (
-	"sort"
+	"bytes"
+	"strings"
 )
 
 // Order is an object used to order objects
 type Order interface {
-
-	// Sort sorts the Entry slice according to
-	// the Order criteria.
-	Sort([]Entry)
+	Compare(a, b Entry) int
 }
 
-// OrderByValue is used to signal to datastores they
-// should apply internal orderings. unfortunately, there
-// is no way to apply order comparisons to interface{} types
-// in Go, so if the datastore doesnt have a special way to
-// handle these comparisons, you must provide an Order
-// implementation that casts to the correct type.
-type OrderByValue struct {
-	TypedOrder Order
+// OrderByFunction orders the results based on the result of the given function.
+type OrderByFunction func(a, b Entry) int
+
+func (o OrderByFunction) Compare(a, b Entry) int {
+	return o(a, b)
 }
 
-func (o OrderByValue) Sort(res []Entry) {
-	if o.TypedOrder == nil {
-		panic("cannot order interface{} by value. see query docs.")
-	}
-	o.TypedOrder.Sort(res)
+// OrderByValue is used to signal to datastores they should apply internal
+// orderings.
+type OrderByValue struct{}
+
+func (o OrderByValue) Compare(a, b Entry) int {
+	return bytes.Compare(a.Value, b.Value)
 }
 
 // OrderByValueDescending is used to signal to datastores they
-// should apply internal orderings. unfortunately, there
-// is no way to apply order comparisons to interface{} types
-// in Go, so if the datastore doesnt have a special way to
-// handle these comparisons, you are SOL.
-type OrderByValueDescending struct {
-	TypedOrder Order
-}
+// should apply internal orderings.
+type OrderByValueDescending struct{}
 
-func (o OrderByValueDescending) Sort(res []Entry) {
-	if o.TypedOrder == nil {
-		panic("cannot order interface{} by value. see query docs.")
-	}
-	o.TypedOrder.Sort(res)
+func (o OrderByValueDescending) Compare(a, b Entry) int {
+	return -bytes.Compare(a.Value, b.Value)
 }
 
 // OrderByKey
 type OrderByKey struct{}
 
-func (o OrderByKey) Sort(res []Entry) {
-	sort.Stable(reByKey(res))
+func (o OrderByKey) Compare(a, b Entry) int {
+	return strings.Compare(a.Key, b.Key)
 }
 
 // OrderByKeyDescending
 type OrderByKeyDescending struct{}
 
-func (o OrderByKeyDescending) Sort(res []Entry) {
-	sort.Stable(sort.Reverse(reByKey(res)))
+func (o OrderByKeyDescending) Compare(a, b Entry) int {
+	return -strings.Compare(a.Key, b.Key)
 }
-
-type reByKey []Entry
-
-func (s reByKey) Len() int           { return len(s) }
-func (s reByKey) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
-func (s reByKey) Less(i, j int) bool { return s[i].Key < s[j].Key }

--- a/query/query.go
+++ b/query/query.go
@@ -60,7 +60,7 @@ cost of the layer of abstraction.
 type Query struct {
 	Prefix            string   // namespaces the query to results whose keys have Prefix
 	Filters           []Filter // filter results. apply sequentially
-	Orders            []Order  // order results. apply sequentially
+	Orders            []Order  // order results. apply hierarchically
 	Limit             int      // maximum number of results
 	Offset            int      // skip given number of results
 	KeysOnly          bool     // return only keys.


### PR DESCRIPTION
This applies orders hierarchically. Unfortunately, the interfaces had to be changed significantly to get this to work.

For example `[OrderByValue{}, SortByKey{}]` *used* to re-sort by key, throwing away the value sort. Now, this acts like a normal database and `SortByKey` will only sort within equivalent values.

**[[BREAKING CHANGE]]**

PRs for datastores:

* go-ds-badger - https://github.com/ipfs/go-ds-badger/pull/44
* go-ds-flatfs - doesn't even support this.
* go-ds-leveldb - https://github.com/ipfs/go-ds-leveldb/pull/23
* sql-datastore - https://github.com/whyrusleeping/sql-datastore/pull/6

(and probably more)

This is all because we had to change `NaiveOrder`. Unfortunately, the old interface simply can't support this kind of sorting.