### PR TITLE
remove io.Closer from the transaction interface

### DIFF
--- a/datastore.go
+++ b/datastore.go
@@ -171,7 +171,8 @@ type TTLDatastore interface {
 // Commit has been made. Likewise, transactions can be aborted by calling
 // Discard before a successful Commit has been made.
 type Txn interface {
-	Datastore
+	Read
+	Write
 
 	// Commit finalizes a transaction, attempting to commit it to the Datastore.
 	// May return an error if the transaction has gone stale. The presence of an


### PR DESCRIPTION
Transactions shouldn't have to implement Close.

fixes https://github.com/ipfs/go-ds-leveldb/issues/24