### PR TITLE
Splinter TTLDatastore interface into TTL + Datastore

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-3.6.0: Qmdaa4JxUkSS7yuV4tbfe3jdq32dUFGrHbjqRwkthTcvZy
+3.6.1: QmUadX5EcvrBmxAV9sE7wUWtWSqxns5K84qKJBixmcT1w9

--- a/datastore.go
+++ b/datastore.go
@@ -159,7 +159,11 @@ func DiskUsage(d Datastore) (uint64, error) {
 // support expiring entries.
 type TTLDatastore interface {
 	Datastore
+	TTL
+}
 
+// TTL encapulates the methods that deal with entries with time-to-live.
+type TTL interface {
 	PutWithTTL(key Key, value []byte, ttl time.Duration) error
 	SetTTL(key Key, ttl time.Duration) error
 	GetExpiration(key Key) (time.Time, error)

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
   "license": "MIT",
   "name": "go-datastore",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "3.6.0"
+  "version": "3.6.1"
 }
 


### PR DESCRIPTION
After introducing the Close method in Datastore, we no longer had an interface to encapsulate only TTL methods, which broke go-ds-badger tests.