### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/key.go
+++ b/key.go
@@ -239,7 +239,7 @@ func (k Key) MarshalJSON() ([]byte, error) {
 	return json.Marshal(k.String())
 }
 
-// MarshalJSON implements the json.Unmarshaler interface,
+// UnmarshalJSON implements the json.Unmarshaler interface,
 // keys will parse any value specified as a key to a string
 func (k *Key) UnmarshalJSON(data []byte) error {
 	var key string


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?