### PR TITLE
Fix – sorted limited offset mount queries

### DIFF
--- a/mount/mount.go
+++ b/mount/mount.go
@@ -222,10 +222,10 @@ func (d *Datastore) Delete(key ds.Key) error {
 
 func (d *Datastore) Query(master query.Query) (query.Results, error) {
 	childQuery := query.Query{
-		Prefix: master.Prefix,
-		Limit:  master.Limit,
-		Orders: master.Orders,
-		KeysOnly: master.KeysOnly,
+		Prefix:            master.Prefix,
+		Limit:             master.Limit,
+		Orders:            master.Orders,
+		KeysOnly:          master.KeysOnly,
 		ReturnExpirations: master.ReturnExpirations,
 	}
 

--- a/mount/mount.go
+++ b/mount/mount.go
@@ -230,6 +230,10 @@ func (d *Datastore) Query(q query.Query) (query.Results, error) {
 	prefix := ds.NewKey(q.Prefix)
 	dses, mounts, rests := d.lookupAll(prefix)
 
+	// offset needs to be applied after the results are aggregated
+	offset := q.Offset
+	q.Offset = 0
+
 	queries := &querySet{
 		query: q,
 		heads: make([]*queryResults, 0, len(dses)),
@@ -256,7 +260,7 @@ func (d *Datastore) Query(q query.Query) (query.Results, error) {
 		Close: queries.close,
 	})
 
-	return query.NaiveLimit(qr, q.Limit), nil
+	return query.NaiveLimit(query.NaiveOffset(qr, offset), q.Limit), nil
 }
 
 func (d *Datastore) Close() error {

--- a/mount/mount.go
+++ b/mount/mount.go
@@ -262,7 +262,15 @@ func (d *Datastore) Query(q query.Query) (query.Results, error) {
 		Close: queries.close,
 	})
 
-	return query.NaiveLimit(query.NaiveOffset(qr, offset), q.Limit), nil
+	if offset > 0 {
+		qr = query.NaiveOffset(qr, offset)
+	}
+
+	if q.Limit > 0 {
+		qr = query.NaiveLimit(qr, q.Limit)
+	}
+
+	return qr, nil
 }
 
 func (d *Datastore) Close() error {

--- a/mount/mount.go
+++ b/mount/mount.go
@@ -140,11 +140,12 @@ func (h *querySet) next() (query.Result, bool) {
 	head := h.heads[0]
 	next := head.next
 
-	for head.advance() {
+	if head.advance() {
 		heap.Fix(h, 0)
-		return next, true
+	} else {
+		heap.Remove(h, 0)
 	}
-	heap.Remove(h, 0)
+
 	return next, true
 }
 

--- a/mount/mount.go
+++ b/mount/mount.go
@@ -139,6 +139,7 @@ func (h *querySet) next() (query.Result, bool) {
 	}
 	head := h.heads[0]
 	next := head.next
+
 	for head.advance() {
 		if head.next.Error == nil {
 			for _, f := range h.query.Filters {
@@ -146,6 +147,7 @@ func (h *querySet) next() (query.Result, bool) {
 					continue
 				}
 			}
+			// can limit and offset be implemented here?
 		}
 		heap.Fix(h, 0)
 		return next, true

--- a/mount/mount_test.go
+++ b/mount/mount_test.go
@@ -239,7 +239,7 @@ func TestQuerySimple(t *testing.T) {
 	}
 }
 
-func TestQueryCross(t *testing.T) {
+func TestQueryAcrossMounts(t *testing.T) {
 	mapds0 := datastore.NewMapDatastore()
 	mapds1 := datastore.NewMapDatastore()
 	mapds2 := datastore.NewMapDatastore()
@@ -302,7 +302,7 @@ func TestQueryCross(t *testing.T) {
 	}
 }
 
-func TestQueryCrossWithSort(t *testing.T) {
+func TestQueryAcrossMountsWithSort(t *testing.T) {
 	mapds0 := datastore.NewMapDatastore()
 	mapds1 := datastore.NewMapDatastore()
 	mapds2 := datastore.NewMapDatastore()
@@ -351,7 +351,7 @@ func TestQueryCrossWithSort(t *testing.T) {
 	}
 }
 
-func TestQueryLimitCrossWithSort(t *testing.T) {
+func TestQueryLimitAcrossMountsWithSort(t *testing.T) {
 	mapds1 := sync.MutexWrap(datastore.NewMapDatastore())
 	mapds2 := sync.MutexWrap(datastore.NewMapDatastore())
 	mapds3 := sync.MutexWrap(datastore.NewMapDatastore())
@@ -401,7 +401,7 @@ func TestQueryLimitCrossWithSort(t *testing.T) {
 	}
 }
 
-func TestQueryLimitAndOffsetCrossWithSort(t *testing.T) {
+func TestQueryLimitAndOffsetAcrossMountsWithSort(t *testing.T) {
 	mapds1 := sync.MutexWrap(datastore.NewMapDatastore())
 	mapds2 := sync.MutexWrap(datastore.NewMapDatastore())
 	mapds3 := sync.MutexWrap(datastore.NewMapDatastore())

--- a/mount/mount_test.go
+++ b/mount/mount_test.go
@@ -401,6 +401,57 @@ func TestQueryLimitCrossWithSort(t *testing.T) {
 	}
 }
 
+func TestQueryLimitAndOffsetCrossWithSort(t *testing.T) {
+	mapds1 := sync.MutexWrap(datastore.NewMapDatastore())
+	mapds2 := sync.MutexWrap(datastore.NewMapDatastore())
+	mapds3 := sync.MutexWrap(datastore.NewMapDatastore())
+	m := mount.New([]mount.Mount{
+		{Prefix: datastore.NewKey("/rok"), Datastore: mapds1},
+		{Prefix: datastore.NewKey("/zoo"), Datastore: mapds2},
+		{Prefix: datastore.NewKey("/noop"), Datastore: mapds3},
+	})
+
+	m.Put(datastore.NewKey("/rok/0"), []byte("ghi"))
+	m.Put(datastore.NewKey("/zoo/0"), []byte("123"))
+	m.Put(datastore.NewKey("/rok/1"), []byte("def"))
+	m.Put(datastore.NewKey("/zoo/1"), []byte("167"))
+	m.Put(datastore.NewKey("/zoo/2"), []byte("345"))
+	m.Put(datastore.NewKey("/rok/3"), []byte("abc"))
+	m.Put(datastore.NewKey("/zoo/3"), []byte("456"))
+
+	q := query.Query{Limit: 3, Offset: 2, Orders: []query.Order{query.OrderByKey{}}}
+	res, err := m.Query(q)
+	if err != nil {
+		t.Fatalf("Query fail: %v\n", err)
+	}
+
+	entries, err := res.Rest()
+	if err != nil {
+		t.Fatalf("Query Results.Rest fail: %v\n", err)
+	}
+
+	expect := []string{
+		"/rok/3",
+		"/zoo/0",
+		"/zoo/1",
+	}
+
+	if len(entries) != len(expect) {
+		t.Fatalf("expected %d entries, but got %d", len(expect), len(entries))
+	}
+
+	for i, e := range expect {
+		if e != entries[i].Key {
+			t.Errorf("expected key %s, but got %s", e, entries[i].Key)
+		}
+	}
+
+	err = res.Close()
+	if err != nil {
+		t.Errorf("result.Close failed %d", err)
+	}
+}
+
 func TestLookupPrio(t *testing.T) {
 	mapds0 := datastore.NewMapDatastore()
 	mapds1 := datastore.NewMapDatastore()

--- a/mount/mount_test.go
+++ b/mount/mount_test.go
@@ -2,13 +2,13 @@ package mount_test
 
 import (
 	"errors"
-	"github.com/ipfs/go-datastore/sync"
 	"testing"
 
-	"github.com/ipfs/go-datastore"
-	"github.com/ipfs/go-datastore/mount"
-	"github.com/ipfs/go-datastore/query"
-	"github.com/ipfs/go-datastore/test"
+	datastore "github.com/ipfs/go-datastore"
+	mount "github.com/ipfs/go-datastore/mount"
+	query "github.com/ipfs/go-datastore/query"
+	sync "github.com/ipfs/go-datastore/sync"
+	dstest "github.com/ipfs/go-datastore/test"
 )
 
 func TestPutBadNothing(t *testing.T) {

--- a/mount/mount_test.go
+++ b/mount/mount_test.go
@@ -353,14 +353,10 @@ func TestErrQueryClose(t *testing.T) {
 
 	m.Put(datastore.NewKey("/baz"), []byte("123"))
 
-	qr, err := m.Query(query.Query{})
-	if err != nil {
-		t.Fatalf("Query error: %v", err)
-	}
-
-	e, ok := qr.NextSync()
-	if ok != false || e.Error == nil {
-		t.Errorf("Query was ok or q.Error was nil")
+	_, err := m.Query(query.Query{})
+	if err == nil {
+		t.Fatal("expected query to fail")
+		return
 	}
 }
 

--- a/query/order.go
+++ b/query/order.go
@@ -46,3 +46,21 @@ type OrderByKeyDescending struct{}
 func (o OrderByKeyDescending) Compare(a, b Entry) int {
 	return -strings.Compare(a.Key, b.Key)
 }
+
+// Less returns true if a comes before b with the requested orderings.
+func Less(orders []Order, a, b Entry) bool {
+	for _, cmp := range orders {
+		switch cmp.Compare(a, b) {
+		case 0:
+		case -1:
+			return true
+		case 1:
+			return false
+		}
+	}
+
+	// This gives us a *stable* sort for free. We don't care
+	// preserving the order from the underlying datastore
+	// because it's undefined.
+	return a.Key < b.Key
+}

--- a/query/query.go
+++ b/query/query.go
@@ -3,7 +3,7 @@ package query
 import (
 	"time"
 
-	goprocess "github.com/jbenet/goprocess"
+	"github.com/jbenet/goprocess"
 )
 
 /*

--- a/query/query.go
+++ b/query/query.go
@@ -3,7 +3,7 @@ package query
 import (
 	"time"
 
-	"github.com/jbenet/goprocess"
+	goprocess "github.com/jbenet/goprocess"
 )
 
 /*

--- a/query/query_impl.go
+++ b/query/query_impl.go
@@ -1,6 +1,8 @@
 package query
 
-import "sort"
+import (
+	"sort"
+)
 
 func DerivedResults(qr Results, ch <-chan Result) Results {
 	return &results{
@@ -48,7 +50,7 @@ func NaiveLimit(qr Results, limit int) Results {
 		}
 	}()
 
-	return DerivedResults(qr, ch)
+	return ResultsWithChan(qr.Query(), ch)
 }
 
 // NaiveOffset skips a given number of results
@@ -122,6 +124,7 @@ func NaiveQueryApply(q Query, qr Results) Results {
 		qr = NaiveOffset(qr, q.Offset)
 	}
 	if q.Limit != 0 {
+		// TODO: Offset?
 		qr = NaiveLimit(qr, q.Offset)
 	}
 	return qr

--- a/query/query_impl.go
+++ b/query/query_impl.go
@@ -1,8 +1,6 @@
 package query
 
-import (
-	"sort"
-)
+import "sort"
 
 func DerivedResults(qr Results, ch <-chan Result) Results {
 	return &results{
@@ -124,7 +122,6 @@ func NaiveQueryApply(q Query, qr Results) Results {
 		qr = NaiveOffset(qr, q.Offset)
 	}
 	if q.Limit != 0 {
-		// TODO: Offset?
 		qr = NaiveLimit(qr, q.Limit)
 	}
 	return qr

--- a/query/query_impl.go
+++ b/query/query_impl.go
@@ -74,7 +74,7 @@ func NaiveOffset(qr Results, offset int) Results {
 		}
 	}()
 
-	return DerivedResults(qr, ch)
+	return ResultsWithChan(qr.Query(), ch)
 }
 
 // NaiveOrder reorders results according to given orders.

--- a/query/query_impl.go
+++ b/query/query_impl.go
@@ -97,22 +97,7 @@ func NaiveOrder(qr Results, orders ...Order) Results {
 			entries = append(entries, e.Entry)
 		}
 		sort.Slice(entries, func(i int, j int) bool {
-			a, b := entries[i], entries[j]
-
-			for _, cmp := range orders {
-				switch cmp.Compare(a, b) {
-				case 0:
-				case -1:
-					return true
-				case 1:
-					return false
-				}
-			}
-
-			// This gives us a *stable* sort for free. We don't care
-			// preserving the order from the underlying datastore
-			// because it's undefined.
-			return a.Key < b.Key
+			return Less(orders, entries[i], entries[j])
 		})
 
 		for _, e := range entries {

--- a/query/query_impl.go
+++ b/query/query_impl.go
@@ -26,7 +26,7 @@ func NaiveFilter(qr Results, filter Filter) Results {
 		}
 	}()
 
-	return DerivedResults(qr, ch)
+	return ResultsWithChan(qr.Query(), ch)
 }
 
 // NaiveLimit truncates the results to a given int limit
@@ -125,7 +125,7 @@ func NaiveQueryApply(q Query, qr Results) Results {
 	}
 	if q.Limit != 0 {
 		// TODO: Offset?
-		qr = NaiveLimit(qr, q.Offset)
+		qr = NaiveLimit(qr, q.Limit)
 	}
 	return qr
 }


### PR DESCRIPTION
Based on: https://github.com/ipfs/go-datastore/pull/123
Supersedes: https://github.com/ipfs/go-datastore/pull/121

Use NaiveLimit and NaiveOffset to add limit/offset features to queries on mount.