### PR TITLE
MapDatastore: obey KeysOnly

### DIFF
--- a/basic_ds.go
+++ b/basic_ds.go
@@ -64,7 +64,11 @@ func (d *MapDatastore) Delete(key Key) (err error) {
 func (d *MapDatastore) Query(q dsq.Query) (dsq.Results, error) {
 	re := make([]dsq.Entry, 0, len(d.values))
 	for k, v := range d.values {
-		re = append(re, dsq.Entry{Key: k.String(), Value: v})
+		e := dsq.Entry{Key: k.String()}
+		if !q.KeysOnly {
+			e.Value = v
+		}
+		re = append(re, e)
 	}
 	r := dsq.ResultsWithEntries(q, re)
 	r = dsq.NaiveQueryApply(q, r)


### PR DESCRIPTION
We use this datastore in tests all the time so it should match the behavior of _actual_ datastores as much as possible.