### PR TITLE
Misc Typo Fixes

### DIFF
--- a/datastore.go
+++ b/datastore.go
@@ -110,7 +110,7 @@ type CheckedDatastore interface {
 	Check() error
 }
 
-// CheckedDatastore is an interface that should be implemented by datastores
+// ScrubbedDatastore is an interface that should be implemented by datastores
 // which want to provide a mechanism to check data integrity and/or
 // error correction.
 type ScrubbedDatastore interface {

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,6 @@ go-datastore interface, there are several implementations you can choose from:
   good for big blobs, though may be missing few features (some iteration
   settings don't work).
 * https://github.com/ipfs/go-ds-leveldb - Datastore implementation backed
-  by LevelDB database. Geed for small-size values and many keys.
+  by LevelDB database. Good for small-size values and many keys.
 * https://github.com/ipfs/go-ds-badger - A fast datastore implementation
   backed by BadgerDB. Good for most kinds of data.


### PR DESCRIPTION
* Fixes an incorrect comment for ScrubbedDatastore
* Fixes a typo in the `examples` folder