### PR TITLE
add a Size field to Query's Result

### DIFF
--- a/autobatch/autobatch.go
+++ b/autobatch/autobatch.go
@@ -8,7 +8,7 @@ import (
 	dsq "github.com/ipfs/go-datastore/query"
 )
 
-// Datastore implements a go-datatsore.
+// Datastore implements a go-datastore.
 type Datastore struct {
 	child ds.Batching
 

--- a/basic_ds.go
+++ b/basic_ds.go
@@ -61,7 +61,7 @@ func (d *MapDatastore) Delete(key Key) (err error) {
 func (d *MapDatastore) Query(q dsq.Query) (dsq.Results, error) {
 	re := make([]dsq.Entry, 0, len(d.values))
 	for k, v := range d.values {
-		e := dsq.Entry{Key: k.String()}
+		e := dsq.Entry{Key: k.String(), Size: len(v)}
 		if !q.KeysOnly {
 			e.Value = v
 		}

--- a/mount/mount.go
+++ b/mount/mount.go
@@ -227,7 +227,7 @@ func (d *Datastore) Query(master query.Query) (query.Results, error) {
 		Orders:            master.Orders,
 		KeysOnly:          master.KeysOnly,
 		ReturnExpirations: master.ReturnExpirations,
-		ReturnsSize:       master.ReturnsSize,
+		ReturnsSizes:      master.ReturnsSizes,
 	}
 
 	prefix := ds.NewKey(childQuery.Prefix)

--- a/mount/mount.go
+++ b/mount/mount.go
@@ -227,6 +227,7 @@ func (d *Datastore) Query(master query.Query) (query.Results, error) {
 		Orders:            master.Orders,
 		KeysOnly:          master.KeysOnly,
 		ReturnExpirations: master.ReturnExpirations,
+		ReturnsSize:       master.ReturnsSize,
 	}
 
 	prefix := ds.NewKey(childQuery.Prefix)

--- a/namespace/namespace_test.go
+++ b/namespace/namespace_test.go
@@ -101,9 +101,9 @@ func (ks *DSSuite) TestQuery(c *C) {
 	c.Check(err, Equals, nil)
 
 	expect := []dsq.Entry{
-		{Key: "/bar", Value: []byte("/foo/bar")},
-		{Key: "/bar/baz", Value: []byte("/foo/bar/baz")},
-		{Key: "/baz/abc", Value: []byte("/foo/baz/abc")},
+		{Key: "/bar", Size: len([]byte("/foo/bar")), Value: []byte("/foo/bar")},
+		{Key: "/bar/baz", Size: len([]byte("/foo/bar/baz")), Value: []byte("/foo/bar/baz")},
+		{Key: "/baz/abc", Size: len([]byte("/foo/baz/abc")), Value: []byte("/foo/baz/abc")},
 	}
 
 	results, err := qres.Rest()
@@ -122,8 +122,8 @@ func (ks *DSSuite) TestQuery(c *C) {
 	c.Check(err, Equals, nil)
 
 	expect = []dsq.Entry{
-		{Key: "/bar", Value: []byte("/foo/bar")},
-		{Key: "/bar/baz", Value: []byte("/foo/bar/baz")},
+		{Key: "/bar", Size: len([]byte("/foo/bar")), Value: []byte("/foo/bar")},
+		{Key: "/bar/baz", Size: len([]byte("/foo/bar/baz")), Value: []byte("/foo/bar/baz")},
 	}
 
 	results, err = qres.Rest()

--- a/query/query.go
+++ b/query/query.go
@@ -66,7 +66,7 @@ type Query struct {
 	Offset            int      // skip given number of results
 	KeysOnly          bool     // return only keys.
 	ReturnExpirations bool     // return expirations (see TTLDatastore)
-	ReturnsSize       bool     // always return sizes. If not set, datastore impl can return
+	ReturnsSizes      bool     // always return sizes. If not set, datastore impl can return
 	//                         // it anyway if it doesn't involve a performance cost. If KeysOnly
 	//                         // is not set, Size should always be set.
 }

--- a/query/query.go
+++ b/query/query.go
@@ -66,6 +66,9 @@ type Query struct {
 	Offset            int      // skip given number of results
 	KeysOnly          bool     // return only keys.
 	ReturnExpirations bool     // return expirations (see TTLDatastore)
+	ReturnsSize       bool     // always return sizes. If not set, datastore impl can return
+	//                         // it anyway if it doesn't involve a performance cost. If KeysOnly
+	//                         // is not set, Size should always be set.
 }
 
 // String returns a string represenation of the Query for debugging/validation
@@ -115,9 +118,10 @@ func (q Query) String() string {
 // Entry is a query result entry.
 type Entry struct {
 	Key        string    // cant be ds.Key because circular imports ...!!!
-	Size       int       // Might be zero if the datastore doesn't support listing the size with KeysOnly
 	Value      []byte    // Will be nil if KeysOnly has been passed.
 	Expiration time.Time // Entry expiration timestamp if requested and supported (see TTLDatastore).
+	Size       int       // Might be -1 if the datastore doesn't support listing the size with KeysOnly
+	//                   // or if ReturnsSizes is not set
 }
 
 // Result is a special entry that includes an error, so that the client

--- a/query/query.go
+++ b/query/query.go
@@ -115,6 +115,7 @@ func (q Query) String() string {
 // Entry is a query result entry.
 type Entry struct {
 	Key        string    // cant be ds.Key because circular imports ...!!!
+	Size       int       // Might be zero if the datastore doesn't support listing the size with KeysOnly
 	Value      []byte    // Will be nil if KeysOnly has been passed.
 	Expiration time.Time // Entry expiration timestamp if requested and supported (see TTLDatastore).
 }

--- a/query/query_impl.go
+++ b/query/query_impl.go
@@ -136,7 +136,7 @@ func NaiveQueryApply(q Query, qr Results) Results {
 func ResultEntriesFrom(keys []string, vals [][]byte) []Entry {
 	re := make([]Entry, len(keys))
 	for i, k := range keys {
-		re[i] = Entry{Key: k, Value: vals[i]}
+		re[i] = Entry{Key: k, Size: len(vals[i]), Value: vals[i]}
 	}
 	return re
 }

--- a/test/basic_tests.go
+++ b/test/basic_tests.go
@@ -315,6 +315,7 @@ func subtestQuery(t *testing.T, ds dstore.Datastore, q dsq.Query, count int) {
 		value := randValue()
 		input = append(input, dsq.Entry{
 			Key:   key,
+			Size:  len(value),
 			Value: value,
 		})
 	}

--- a/test/basic_tests.go
+++ b/test/basic_tests.go
@@ -301,6 +301,10 @@ func SubtestFilter(t *testing.T, ds dstore.Datastore) {
 	test(new(testFilter))
 }
 
+func SubtestReturnSizes(t *testing.T, ds dstore.Datastore) {
+	subtestQuery(t, ds, dsq.Query{ReturnsSizes: true}, 100)
+}
+
 func randValue() []byte {
 	value := make([]byte, 64)
 	rand.Read(value)
@@ -376,7 +380,9 @@ func subtestQuery(t *testing.T, ds dstore.Datastore, q dsq.Query, count int) {
 		if !q.KeysOnly && !bytes.Equal(actual[i].Value, expected[i].Value) {
 			t.Errorf("value mismatch for result %d (key=%q)", i, expected[i].Key)
 		}
-
+		if q.ReturnsSizes && actual[i].Size <= 0 {
+			t.Errorf("for result %d, expected size > 0 with ReturnsSizes", i)
+		}
 	}
 
 	t.Log("deleting all keys")

--- a/test/suite.go
+++ b/test/suite.go
@@ -18,6 +18,7 @@ var BasicSubtests = []func(t *testing.T, ds dstore.Datastore){
 	SubtestLimit,
 	SubtestFilter,
 	SubtestManyKeysAndQuery,
+	SubtestReturnSizes,
 }
 
 // BatchSubtests is a list of all basic batching datastore tests.


### PR DESCRIPTION
Rational is that some datastore can easilty get the size of a value when listing only keys, so we might as well have a way to pass that. One way this could be useful is when implementing a cache for Has/GetSize.