### PR TITLE
Support Asynchronous Writing Datastores

### DIFF
--- a/autobatch/autobatch.go
+++ b/autobatch/autobatch.go
@@ -64,6 +64,35 @@ func (d *Datastore) Put(k ds.Key, val []byte) error {
 	return nil
 }
 
+// Sync flushes all operations on keys at or under the prefix
+// from the current batch to the underlying datastore
+func (d *Datastore) Sync(prefix ds.Key) error {
+	b, err := d.child.Batch()
+	if err != nil {
+		return err
+	}
+
+	for k, o := range d.buffer {
+		if !(k.Equal(prefix) || k.IsDescendantOf(prefix)) {
+			continue
+		}
+
+		var err error
+		if o.delete {
+			err = b.Delete(k)
+		} else {
+			err = b.Put(k, o.value)
+		}
+		if err != nil {
+			return err
+		}
+
+		delete(d.buffer, k)
+	}
+
+	return b.Commit()
+}
+
 // Flush flushes the current batch to the underlying datastore.
 func (d *Datastore) Flush() error {
 	b, err := d.child.Batch()

--- a/basic_ds.go
+++ b/basic_ds.go
@@ -28,6 +28,11 @@ func (d *MapDatastore) Put(key Key, value []byte) (err error) {
 	return nil
 }
 
+// Sync implements Datastore.Sync
+func (d *MapDatastore) Sync(prefix Key) error {
+	return nil
+}
+
 // Get implements Datastore.Get
 func (d *MapDatastore) Get(key Key) (value []byte, err error) {
 	val, found := d.values[key]
@@ -92,6 +97,11 @@ func NewNullDatastore() *NullDatastore {
 
 // Put implements Datastore.Put
 func (d *NullDatastore) Put(key Key, value []byte) (err error) {
+	return nil
+}
+
+// Sync implements Datastore.Sync
+func (d *NullDatastore) Sync(prefix Key) error {
 	return nil
 }
 

--- a/datastore.go
+++ b/datastore.go
@@ -34,6 +34,13 @@ should be checked by callers.
 type Datastore interface {
 	Read
 	Write
+	// Sync guarantees that any Put or Delete calls under prefix that returned
+	// before Sync(prefix) was called will be observed after Sync(prefix)
+	// returns, even if the program crashes. If Put/Delete operations already
+	// satisfy these requirements then Sync may be a no-op.
+	//
+	// If the prefix fails to Sync this method returns an error.
+	Sync(prefix Key) error
 	io.Closer
 }
 

--- a/delayed/delayed.go
+++ b/delayed/delayed.go
@@ -30,6 +30,12 @@ func (dds *Delayed) Put(key ds.Key, value []byte) (err error) {
 	return dds.ds.Put(key, value)
 }
 
+// Sync implements Datastore.Sync
+func (dds *Delayed) Sync(prefix ds.Key) error {
+	dds.delay.Wait()
+	return dds.ds.Sync(prefix)
+}
+
 // Get implements the ds.Datastore interface.
 func (dds *Delayed) Get(key ds.Key) (value []byte, err error) {
 	dds.delay.Wait()

--- a/examples/fs.go
+++ b/examples/fs.go
@@ -63,6 +63,12 @@ func (d *Datastore) Put(key ds.Key, value []byte) (err error) {
 	return ioutil.WriteFile(fn, value, 0666)
 }
 
+// Sync would ensure that any previous Puts under the prefix are written to disk.
+// However, they already are.
+func (d *Datastore) Sync(prefix ds.Key) error {
+	return nil
+}
+
 // Get returns the value for given key
 func (d *Datastore) Get(key ds.Key) (value []byte, err error) {
 	fn := d.KeyFilename(key)

--- a/examples/fs.go
+++ b/examples/fs.go
@@ -103,8 +103,9 @@ func (d *Datastore) Query(q query.Query) (query.Results, error) {
 
 	walkFn := func(path string, info os.FileInfo, err error) error {
 		// remove ds path prefix
-		if strings.HasPrefix(path, d.path) {
-			path = path[len(d.path):]
+		relPath, err := filepath.Rel(d.path, path)
+		if err == nil {
+			path = filepath.ToSlash(relPath)
 		}
 
 		if !info.IsDir() {
@@ -167,7 +168,7 @@ func (d *Datastore) DiskUsage() (uint64, error) {
 			log.Println(err)
 			return err
 		}
-		if f != nil {
+		if f != nil && f.Mode().IsRegular() {
 			du += uint64(f.Size())
 		}
 		return nil

--- a/examples/fs_test.go
+++ b/examples/fs_test.go
@@ -96,13 +96,16 @@ func (ks *DSSuite) TestDiskUsage(c *C) {
 		"foo/bar/baz/barb",
 	})
 
+	totalBytes := 0
 	for _, k := range keys {
-		err := ks.ds.Put(k, []byte(k.String()))
+		value := []byte(k.String())
+		totalBytes += len(value)
+		err := ks.ds.Put(k, value)
 		c.Check(err, Equals, nil)
 	}
 
 	if ps, ok := ks.ds.(ds.PersistentDatastore); ok {
-		if s, err := ps.DiskUsage(); s <= 100 || err != nil {
+		if s, err := ps.DiskUsage(); s != uint64(totalBytes) || err != nil {
 			c.Error("unexpected size is: ", s)
 		}
 	} else {

--- a/failstore/failstore.go
+++ b/failstore/failstore.go
@@ -36,6 +36,16 @@ func (d *Failstore) Put(k ds.Key, val []byte) error {
 	return d.child.Put(k, val)
 }
 
+// Sync implements Datastore.Sync
+func (d *Failstore) Sync(prefix ds.Key) error {
+	err := d.errfunc("sync")
+	if err != nil {
+		return err
+	}
+
+	return d.child.Sync(prefix)
+}
+
 // Get retrieves a value from the datastore.
 func (d *Failstore) Get(k ds.Key) ([]byte, error) {
 	err := d.errfunc("get")

--- a/keytransform/keytransform.go
+++ b/keytransform/keytransform.go
@@ -37,6 +37,11 @@ func (d *Datastore) Put(key ds.Key, value []byte) (err error) {
 	return d.child.Put(d.ConvertKey(key), value)
 }
 
+// Sync implements Datastore.Sync
+func (d *Datastore) Sync(prefix ds.Key) error {
+	return d.child.Sync(d.ConvertKey(prefix))
+}
+
 // Get returns the value for given key, transforming the key first.
 func (d *Datastore) Get(key ds.Key) (value []byte, err error) {
 	return d.child.Get(d.ConvertKey(key))

--- a/mount/mount.go
+++ b/mount/mount.go
@@ -189,6 +189,24 @@ func (d *Datastore) Put(key ds.Key, value []byte) error {
 	return cds.Put(k, value)
 }
 
+// Sync implements Datastore.Sync
+func (d *Datastore) Sync(prefix ds.Key) error {
+	// Sync all mount points below the prefix
+	// Sync the mount point right at (or above) the prefix
+	dstores, mountPts, rest := d.lookupAll(prefix)
+	for i, suffix := range rest {
+		if err := dstores[i].Sync(suffix); err != nil {
+			return err
+		}
+
+		if mountPts[i].Equal(prefix) || suffix.String() != "/" {
+			return nil
+		}
+	}
+
+	return nil
+}
+
 func (d *Datastore) Get(key ds.Key) (value []byte, err error) {
 	cds, _, k := d.lookup(key)
 	if cds == nil {

--- a/retrystore/retrystore.go
+++ b/retrystore/retrystore.go
@@ -73,6 +73,13 @@ func (d *Datastore) Put(k ds.Key, val []byte) error {
 	})
 }
 
+// Sync implements Datastore.Sync
+func (d *Datastore) Sync(prefix ds.Key) error {
+	return d.runOp(func() error {
+		return d.Batching.Sync(prefix)
+	})
+}
+
 // Has checks if a key is stored.
 func (d *Datastore) Has(k ds.Key) (bool, error) {
 	var has bool

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -33,6 +33,13 @@ func (d *MutexDatastore) Put(key ds.Key, value []byte) (err error) {
 	return d.child.Put(key, value)
 }
 
+// Sync implements Datastore.Sync
+func (d *MutexDatastore) Sync(prefix ds.Key) error {
+	d.Lock()
+	defer d.Unlock()
+	return d.child.Sync(prefix)
+}
+
 // Get implements Datastore.Get
 func (d *MutexDatastore) Get(key ds.Key) (value []byte, err error) {
 	d.RLock()

--- a/test/basic_tests.go
+++ b/test/basic_tests.go
@@ -176,6 +176,36 @@ func SubtestManyKeysAndQuery(t *testing.T, ds dstore.Datastore) {
 	subtestQuery(t, ds, dsq.Query{KeysOnly: true}, 100)
 }
 
+func SubtestBasicSync(t *testing.T, ds dstore.Datastore) {
+	if err := ds.Sync(dstore.NewKey("foo")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ds.Put(dstore.NewKey("/foo"), []byte("foo")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ds.Sync(dstore.NewKey("/foo")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ds.Put(dstore.NewKey("/foo/bar"), []byte("bar")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ds.Sync(dstore.NewKey("/foo")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ds.Sync(dstore.NewKey("/foo/bar")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ds.Sync(dstore.NewKey("")); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // need a custom test filter to test the "fallback" filter case for unknown
 // filters.
 type testFilter struct{}

--- a/test/suite.go
+++ b/test/suite.go
@@ -19,6 +19,7 @@ var BasicSubtests = []func(t *testing.T, ds dstore.Datastore){
 	SubtestFilter,
 	SubtestManyKeysAndQuery,
 	SubtestReturnSizes,
+	SubtestBasicSync,
 }
 
 // BatchSubtests is a list of all basic batching datastore tests.


### PR DESCRIPTION
Per #137 we would like to support Datastores that internally have asynchronous writes. We are doing this by adding a `Sync(prefix ds.Key)` function to the Datastore interface.

The plan is:
1) Get this PR reviewed for a sanity check
2) Get the datastore PRs submitted and reviewed and ready to be accepted (their go.mod files will reference this PR's branch)
   - [x] https://github.com/ipfs/go-ds-measure/pull/23
   -  [x] https://github.com/ipfs/go-ds-s3/pull/46
   -  [x] https://github.com/ipfs/go-ds-redis/pull/6
   -  [x] https://github.com/ipfs/go-ds-leveldb/pull/36
   -  [x] https://github.com/ipfs/go-ds-flatfs/pull/60
   -  [x] https://github.com/ipfs/go-ds-badger/pull/77
   - Note: If some of the datastores are proving tricky to write a Sync command for we may not block for them all to be approved before we continue.
3) Merge this PR
4) Update and merge the other PRs
5) Update some areas of go-ipfs to use the `Sync()` command on their datastores
6) Switch the default datastore in go-ipfs to be an asynchronous one (i.e. Badger with Async writes enabled)