### PR TITLE
fix go-check path to use "gopkg.in/check.v1"

### DIFF
--- a/examples/fs_test.go
+++ b/examples/fs_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	. "github.com/go-check/check"
+	. "gopkg.in/check.v1"
 
 	ds "github.com/ipfs/go-datastore"
 	query "github.com/ipfs/go-datastore/query"

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/jbenet/goprocess v0.0.0-20160826012719-b497e2f366b8
 	github.com/kr/pretty v0.1.0 // indirect
 	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
-	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
+	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
 )
 
 go 1.12

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,12 @@
 module github.com/ipfs/go-datastore
 
 require (
-	github.com/go-check/check v0.0.0-20180628173108-788fd7840127
 	github.com/google/uuid v1.1.1
 	github.com/ipfs/go-ipfs-delay v0.0.0-20181109222059-70721b86a9a8
 	github.com/jbenet/goprocess v0.0.0-20160826012719-b497e2f366b8
 	github.com/kr/pretty v0.1.0 // indirect
 	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
-	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
+	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
 )
 
 go 1.12

--- a/go.sum
+++ b/go.sum
@@ -11,5 +11,5 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/go-check/check v0.0.0-20180628173108-788fd7840127 h1:0gkP6mzaMqkmpcJYCFOLkIBwI7xFExG03bbkOkCvUPI=
-github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/ipfs/go-ipfs-delay v0.0.0-20181109222059-70721b86a9a8 h1:NAviDvJ0WXgD+yiL2Rj35AmnfgI11+pHXbdciD917U0=

--- a/key_test.go
+++ b/key_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/go-check/check"
+	. "gopkg.in/check.v1"
 	. "github.com/ipfs/go-datastore"
 )
 

--- a/key_test.go
+++ b/key_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	. "gopkg.in/check.v1"
 	. "github.com/ipfs/go-datastore"
+	. "gopkg.in/check.v1"
 )
 
 // Hook up gocheck into the "go test" runner.

--- a/keytransform/keytransform_test.go
+++ b/keytransform/keytransform_test.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"testing"
 
-	. "github.com/go-check/check"
+	. "gopkg.in/check.v1"
 
 	ds "github.com/ipfs/go-datastore"
 	kt "github.com/ipfs/go-datastore/keytransform"

--- a/namespace/namespace_test.go
+++ b/namespace/namespace_test.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"testing"
 
-	. "github.com/go-check/check"
+	. "gopkg.in/check.v1"
 
 	ds "github.com/ipfs/go-datastore"
 	ns "github.com/ipfs/go-datastore/namespace"

--- a/query/query.go
+++ b/query/query.go
@@ -71,7 +71,7 @@ type Query struct {
 	//                         // is not set, Size should always be set.
 }
 
-// String returns a string represenation of the Query for debugging/validation
+// String returns a string representation of the Query for debugging/validation
 // purposes. Do not use it for SQL queries.
 func (q Query) String() string {
 	s := "SELECT keys"
@@ -157,7 +157,7 @@ type Result struct {
 type Results interface {
 	Query() Query             // the query these Results correspond to
 	Next() <-chan Result      // returns a channel to wait for the next result
-	NextSync() (Result, bool) // blocks and waits to return the next result, second paramter returns false when results are exhausted
+	NextSync() (Result, bool) // blocks and waits to return the next result, second parameter returns false when results are exhausted
 	Rest() ([]Entry, error)   // waits till processing finishes, returns all entries at once.
 	Close() error             // client may call Close to signal early exit
 

--- a/test/test_util.go
+++ b/test/test_util.go
@@ -36,7 +36,7 @@ func RunBatchTest(t *testing.T, ds dstore.Batching) {
 		}
 	}
 
-	// Ensure they are not in the datastore before comitting
+	// Ensure they are not in the datastore before committing
 	for _, k := range keys {
 		_, err := ds.Get(k)
 		if err == nil {


### PR DESCRIPTION
Solves the problem of `check` being required by two different paths, which creates errors when running `go test all`.

Also, updates check to the latest version, and fix 3 spelling mistakes fixed by `misspell`.