### PR TITLE
fix: avoid filtering by prefix unless necessary

### DIFF
--- a/query/query_impl.go
+++ b/query/query_impl.go
@@ -129,12 +129,10 @@ func NaiveQueryApply(q Query, qr Results) Results {
 			}
 			prefix = path.Clean(prefix)
 		}
-		// If the prefix isn't "/", end it in a "/" so we only find keys
-		// _under_ the prefix.
+		// If the prefix is empty, ignore it.
 		if prefix != "/" {
-			prefix += "/"
+			qr = NaiveFilter(qr, FilterKeyPrefix{prefix + "/"})
 		}
-		qr = NaiveFilter(qr, FilterKeyPrefix{prefix})
 	}
 	for _, f := range q.Filters {
 		qr = NaiveFilter(qr, f)


### PR DESCRIPTION
There's no need to filter by the / prefix.