### PR TITLE
/test: fix bad ElemCount/10 lenght (should not be divided)

### DIFF
--- a/test/basic_tests.go
+++ b/test/basic_tests.go
@@ -262,7 +262,7 @@ func SubtestCombinations(t *testing.T, ds dstore.Datastore) {
 	lengths := []int{
 		0,
 		1,
-		ElemCount / 10,
+		ElemCount,
 	}
 	perms(
 		func(perm []int) {


### PR DESCRIPTION
I had changed this manually and then missed it.