### PR TITLE
Add LRUStore datastore wrapper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/ipfs/go-datastore
 
 require (
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/google/uuid v1.1.1
 	github.com/ipfs/go-detect-race v0.0.1
 	github.com/ipfs/go-ipfs-delay v0.0.0-20181109222059-70721b86a9a8

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
+github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/lrustore/lrustore.go
+++ b/lrustore/lrustore.go
@@ -1,0 +1,269 @@
+// Package lrustore provides a datastore wrapper that limits the number of
+// items stored to the specified capacity. When at capacity, the oldest items
+// are removed in LRU to make root for new items.  Putting and getting items
+// maintains LRU order.
+package lrustore
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	lru "github.com/golang/groupcache/lru"
+	ds "github.com/ipfs/go-datastore"
+	dsq "github.com/ipfs/go-datastore/query"
+)
+
+// LRUStore is a LRU-cache that stores keys in memory and values in a datastore.
+type LRUStore struct {
+	dstore ds.Datastore
+	lru    *lru.Cache
+	lock   sync.RWMutex
+	rmErr  error
+	rmCtx  context.Context
+}
+
+var _ ds.Datastore = (*LRUStore)(nil)
+var _ ds.Batching = (*LRUStore)(nil)
+var _ ds.PersistentDatastore = (*LRUStore)(nil)
+
+// New creates a new LRUStore instance.  The context is only used cancel
+// a call to this function while it is accessing the data store.
+func New(ctx context.Context, dstore ds.Datastore, capacity int) (*LRUStore, error) {
+	// Create LRU cache that deletes value from datastore when key is evicted
+	// from cache.
+	cache := lru.New(capacity)
+
+	ls := &LRUStore{
+		dstore: dstore,
+		lru:    cache,
+	}
+
+	// Load all keys from datastore into lru cache.
+	if err := ls.loadKeys(ctx); err != nil {
+		return nil, err
+	}
+
+	// Set the function to remove items from the datastore when they are
+	// evicted from lru.
+	cache.OnEvicted = func(key lru.Key, val interface{}) {
+		// Remove item from datastore that was evicted from LRU.
+		err := dstore.Delete(ls.rmCtx, key.(ds.Key))
+		if err != nil {
+			ls.rmErr = err
+		}
+	}
+
+	return ls, nil
+}
+
+// Get implements datastore interface.
+func (ls *LRUStore) Get(ctx context.Context, key ds.Key) ([]byte, error) {
+	ls.lock.RLock()
+	defer ls.lock.RUnlock()
+
+	_, ok := ls.lru.Get(key)
+	if !ok {
+		return nil, ds.ErrNotFound
+	}
+	val, err := ls.dstore.Get(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	return val, nil
+}
+
+// Put implements datastore interface.
+func (ls *LRUStore) Put(ctx context.Context, key ds.Key, val []byte) error {
+	ls.lock.Lock()
+	defer ls.lock.Unlock()
+
+	ls.rmCtx = ctx
+	ls.lru.Add(key, nil)
+	ls.rmCtx = nil
+
+	// If error evicting old entries, remove key and return error.
+	if ls.rmErr != nil {
+		err := ls.rmErr
+		ls.rmErr = nil
+		ls.lru.Remove(key)
+		return err
+	}
+
+	err := ls.dstore.Put(ctx, key, val)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Delete implements datastore interface.
+func (ls *LRUStore) Delete(ctx context.Context, key ds.Key) error {
+	ls.lock.Lock()
+	defer ls.lock.Unlock()
+
+	ls.rmCtx = ctx
+	ls.lru.Remove(key)
+	ls.rmCtx = nil
+
+	// If there was an error evicting old entries, return it.
+	if ls.rmErr != nil {
+		err := ls.rmErr
+		ls.rmErr = nil
+		return err
+	}
+	return nil
+}
+
+// GetSize implements datastore interface.
+func (ls *LRUStore) GetSize(ctx context.Context, key ds.Key) (int, error) {
+	ls.lock.RLock()
+	defer ls.lock.RUnlock()
+
+	return ls.dstore.GetSize(ctx, key)
+}
+
+// Has implements datastore interface.  Has determines if the item is present
+// in the LRUStore without moving the item to the newest LRU position.
+func (ls *LRUStore) Has(ctx context.Context, key ds.Key) (bool, error) {
+	ls.lock.RLock()
+	defer ls.lock.RUnlock()
+
+	return ls.dstore.Has(ctx, key)
+}
+
+// Sync implements datastore interface.
+func (ls *LRUStore) Sync(ctx context.Context, key ds.Key) error {
+	ls.lock.Lock()
+	defer ls.lock.Unlock()
+
+	return ls.dstore.Sync(ctx, key)
+}
+
+// Close syncs the LRUStore entries but does not close the underlying
+// datastore.  This is because LRUStore wraps an existing datastore and does
+// not construct it, and the wrapped datastore may be in use elsewhere.
+func (ls *LRUStore) Close() error {
+	return ls.Sync(context.Background(), ds.NewKey(""))
+}
+
+// Query implements datastore interface.
+func (ls *LRUStore) Query(ctx context.Context, q dsq.Query) (dsq.Results, error) {
+	ls.lock.RLock()
+	defer ls.lock.RUnlock()
+
+	return ls.dstore.Query(ctx, q)
+}
+
+// Batch implements the Batching interface.
+func (ls *LRUStore) Batch(ctx context.Context) (ds.Batch, error) {
+	return ds.NewBasicBatch(ls), nil
+}
+
+// DiskUsage implements the PersistentDatastore interface.
+func (ls *LRUStore) DiskUsage(ctx context.Context) (uint64, error) {
+	return ds.DiskUsage(ctx, ls.dstore)
+}
+
+// Cap returns the LRUStore capacity.  Storing more than this number of items
+// results in discarding oldest items.
+func (ls *LRUStore) Cap() int {
+	ls.lock.RLock()
+	defer ls.lock.RUnlock()
+
+	return ls.lru.MaxEntries
+}
+
+// Len returns the number of items in the LRUStore
+func (ls *LRUStore) Len() int {
+	ls.lock.RLock()
+	defer ls.lock.RUnlock()
+
+	return ls.lru.Len()
+}
+
+// Resize changes the LRUStore capacity. If the capacity is decreased below the
+// number of items in the LRUStore, then oldest items are discarded until the
+// LRUStore is filled to the new lower capacity.  Returns the number of items
+// evicted from the LRUStore.
+func (ls *LRUStore) Resize(ctx context.Context, newSize int) (int, error) {
+	ls.lock.Lock()
+	defer ls.lock.Unlock()
+
+	diff := ls.lru.Len() - newSize
+	if diff < 0 {
+		diff = 0
+	}
+	if diff != 0 {
+		ls.rmCtx = ctx
+		for i := 0; i < diff; i++ {
+			ls.lru.RemoveOldest()
+			// If there was an error evicting old entries, return it.
+			if ls.rmErr != nil {
+				err := ls.rmErr
+				ls.rmErr = nil
+				ls.rmCtx = nil
+				return 0, err
+			}
+		}
+		ls.rmCtx = nil
+	}
+
+	ls.lru.MaxEntries = newSize
+	return diff, nil
+}
+
+// Clear purges all stored items from the LRUStore.
+func (ls *LRUStore) Clear(ctx context.Context) error {
+	ls.lock.Lock()
+	defer ls.lock.Unlock()
+
+	ls.rmCtx = ctx
+	ls.lru.Clear()
+	ls.rmCtx = nil
+
+	// If there was an error evicting old entries, return it.
+	if ls.rmErr != nil {
+		err := ls.rmErr
+		ls.rmErr = nil
+		return err
+	}
+	return nil
+}
+
+// loadKeys loads previously stored keys into LRU memory, without any LRU order.
+func (ls *LRUStore) loadKeys(ctx context.Context) error {
+	q := dsq.Query{
+		KeysOnly: true,
+	}
+
+	results, err := ls.dstore.Query(ctx, q)
+	if err != nil {
+		return err
+	}
+	defer results.Close()
+
+	origCap := ls.lru.MaxEntries
+	ls.lru.MaxEntries = 0
+
+	for r := range results.Next() {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if r.Error != nil {
+			return fmt.Errorf("cannot read cache key: %s", r.Error)
+		}
+
+		ls.lru.Add(ds.RawKey(r.Entry.Key), nil)
+	}
+
+	// If the cache was resized to expand beyond its original capacity, then
+	// set its size to only as big as the number of keys read from datastore.
+	// This will be the number of links in the largest list.
+	if ls.lru.Len() > origCap {
+		ls.lru.MaxEntries = ls.lru.Len()
+	} else {
+		ls.lru.MaxEntries = origCap
+	}
+	return nil
+}

--- a/lrustore/lrustore_test.go
+++ b/lrustore/lrustore_test.go
@@ -1,0 +1,364 @@
+package lrustore
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	ds "github.com/ipfs/go-datastore"
+	fs "github.com/ipfs/go-datastore/failstore"
+	dsq "github.com/ipfs/go-datastore/query"
+)
+
+const testCapacity = 5
+
+func TestLRUStore(t *testing.T) {
+	dstore := ds.NewMapDatastore()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	lruStore, err := New(ctx, dstore, testCapacity)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	key := ds.NewKey("hw")
+	val := []byte("hello world")
+
+	// Test Put and Get.
+	err = lruStore.Put(ctx, key, val)
+	if err != nil {
+		t.Fatal(err)
+	}
+	val2, err := lruStore.Get(ctx, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(val2, val) {
+		t.Fatal("wrong value returned")
+	}
+
+	// Test LRUStore eviction.
+	for i := 0; i < lruStore.Cap(); i++ {
+		k := ds.NewKey(fmt.Sprintf("key-%d", i))
+		err = lruStore.Put(ctx, k, []byte(fmt.Sprintf("val-%d", i)))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if lruStore.Len() != lruStore.Cap() {
+		t.Fatalf("expected len to be %d, got %d", lruStore.Cap(), lruStore.Len())
+	}
+	_, err = lruStore.Get(ctx, key)
+	if err != ds.ErrNotFound {
+		t.Fatalf("Expected error %s, got %s", ds.ErrNotFound, err)
+	}
+	_, err = lruStore.dstore.Get(ctx, key)
+	if err != ds.ErrNotFound {
+		t.Fatalf("value for %q was not removed from datastore", key)
+	}
+
+	// Check that key-0 is able to be retrieved
+	key0 := ds.NewKey("key-0")
+	val, err = lruStore.Get(ctx, key0)
+	if err != nil {
+		t.Fatalf("Failed to get key-0: %s", err)
+	}
+	ok, err := lruStore.Has(ctx, key0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("LRUStore should have key-0")
+	}
+	if !bytes.Equal(val, []byte("val-0")) {
+		t.Fatalf("Wrong value for key-0")
+	}
+	sz, err := lruStore.GetSize(ctx, key0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sz != len(val) {
+		t.Fatalf("GetSize returned wrong size for key-0, expected %d, got %d", len(val), sz)
+	}
+
+	// Test loading LRUStore from datastore.
+	lruStore, err = New(ctx, dstore, testCapacity-2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Check that LRUStore was resized.
+	if lruStore.Cap() != testCapacity {
+		t.Fatalf("LRUStore did not resize to %d", testCapacity)
+	}
+	if lruStore.Len() != lruStore.Cap() {
+		t.Fatalf("expected %d items in LRUStore, got %d", lruStore.Cap(), lruStore.Len())
+	}
+
+	// Check that key0 is still present, and make is newest in LRU.
+	_, err = lruStore.Get(ctx, key0)
+	if err != nil {
+		t.Fatalf("Failed to get key-0: %s", err)
+	}
+
+	// Resize LRUStore to something smaller.
+	newCap := lruStore.Len() - 2
+	toEvict := lruStore.Len() - newCap
+	evicted, err := lruStore.Resize(ctx, newCap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evicted != toEvict {
+		t.Fatalf("expected %d items to be evicted, got %d", toEvict, evicted)
+	}
+
+	// Delete key from LRUStore and varify it gets deleted from datastore.
+	prevLen := lruStore.Len()
+	err = lruStore.Delete(ctx, key0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lruStore.Len() != prevLen-1 {
+		t.Fatalf("expected %d items in LRUStore, got %d", prevLen-1, lruStore.Len())
+	}
+	_, err = lruStore.Get(ctx, key0)
+	if err != ds.ErrNotFound {
+		t.Fatalf("Expected error %s, got %s", ds.ErrNotFound, err)
+	}
+	_, err = lruStore.dstore.Get(ctx, key0)
+	if err != ds.ErrNotFound {
+		t.Fatalf("value for %q was not removed from datastore", key0)
+	}
+	ok, err = lruStore.Has(ctx, key0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatal("LRUStore should not have key-0 after Delete")
+	}
+
+	// Test resize larger
+	evicted, err = lruStore.Resize(ctx, lruStore.Cap()*2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evicted != 0 {
+		t.Fatal("increasing capacity should not evict entries")
+	}
+
+	// Test LRUStore Clear.
+	lruStore.Clear(ctx)
+	if lruStore.Len() != 0 {
+		t.Fatal("LRUStore was not purged")
+	}
+	// Check that no keys are loaded from datastore.
+	lruStore, err = New(ctx, dstore, testCapacity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lruStore.Len() != 0 {
+		t.Fatal("LRUStore was not purged")
+	}
+
+	du, err := lruStore.DiskUsage(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if du != 0 {
+		t.Fatal("DiskUsage should be 0")
+	}
+
+	b, err := lruStore.Batch(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b == nil {
+		t.Fatal("nil Batching interface")
+	}
+
+	err = lruStore.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEvictionFail(t *testing.T) {
+	errFailed := errors.New("failed")
+	dstore := fs.NewFailstore(ds.NewMapDatastore(), func(op string) error {
+		if op == "delete" {
+			return errFailed
+		}
+		return nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	lruStore, err := New(ctx, dstore, testCapacity)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Test LRUStore eviction.
+	for i := 0; i < lruStore.Cap(); i++ {
+		k := ds.NewKey(fmt.Sprintf("key-%d", i))
+		err = lruStore.Put(ctx, k, []byte(fmt.Sprintf("val-%d", i)))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	key := ds.NewKey("hw")
+	val := []byte("hello world")
+
+	// Test Put fails when eviction fails.
+	err = lruStore.Put(ctx, key, val)
+	if err != errFailed {
+		t.Fatalf("expected error %q", errFailed)
+	}
+
+	// Check that failed put did not put key into LRUStore.
+	_, err = lruStore.Get(ctx, key)
+	if err != ds.ErrNotFound {
+		t.Fatalf("Expected error %s", ds.ErrNotFound)
+	}
+
+	// Test Delete fails when eviction fails.
+	err = lruStore.Delete(ctx, key)
+	if err != errFailed {
+		t.Fatalf("expected error %q", errFailed)
+	}
+
+	// Test Resize fails when eviction fails.
+	diff, err := lruStore.Resize(ctx, lruStore.Len()-1)
+	if err != errFailed {
+		t.Fatalf("expected error %q", errFailed)
+	}
+	if diff != 0 {
+		t.Fatal("expected diff to be 0 on error")
+	}
+
+	// Test Clear fails when eviction fails.
+	err = lruStore.Clear(ctx)
+	if err != errFailed {
+		t.Fatalf("expected error %q", errFailed)
+	}
+}
+
+func TestGetFail(t *testing.T) {
+	errFailed := errors.New("failed")
+	dstore := fs.NewFailstore(ds.NewMapDatastore(), func(op string) error {
+		if op == "get" {
+			return errFailed
+		}
+		return nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	lruStore, err := New(ctx, dstore, testCapacity)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	key := ds.NewKey("hw")
+	val := []byte("hello world")
+
+	// Test Put and Get.
+	err = lruStore.Put(ctx, key, val)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = lruStore.Get(ctx, key)
+	if err != errFailed {
+		t.Fatalf("expected error %q", errFailed)
+	}
+
+}
+
+func TestPutFail(t *testing.T) {
+	errFailed := errors.New("failed")
+	dstore := fs.NewFailstore(ds.NewMapDatastore(), func(op string) error {
+		if op == "put" {
+			return errFailed
+		}
+		return nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	lruStore, err := New(ctx, dstore, testCapacity)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	key := ds.NewKey("hw")
+	val := []byte("hello world")
+
+	// Test Put and Get.
+	err = lruStore.Put(ctx, key, val)
+	if err != errFailed {
+		t.Fatalf("expected error %q", errFailed)
+	}
+}
+
+func TestQueryFail(t *testing.T) {
+	errFailed := errors.New("failed")
+	enableFail := true
+	dstore := fs.NewFailstore(ds.NewMapDatastore(), func(op string) error {
+		if enableFail && op == "query" {
+			return errFailed
+		}
+		return nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := New(ctx, dstore, testCapacity)
+	if err != errFailed {
+		t.Fatalf("expected error %q", errFailed)
+	}
+
+	enableFail = false
+
+	lruStore, err := New(ctx, dstore, testCapacity)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	enableFail = true
+
+	key := ds.NewKey("hw")
+	val := []byte("hello world")
+
+	// Test Put and Get.
+	err = lruStore.Put(ctx, key, val)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	q := dsq.Query{
+		KeysOnly: true,
+	}
+	_, err = lruStore.Query(ctx, q)
+	if err != errFailed {
+		t.Fatalf("expected error %q", errFailed)
+	}
+
+	// Test that New fails when context is canceled.
+	enableFail = false
+	cancel()
+	_, err = New(ctx, dstore, testCapacity)
+	if err != context.Canceled {
+		t.Fatalf("expected error %q", context.Canceled)
+	}
+
+}


### PR DESCRIPTION
Package `lrustore` provides a datastore wrapper that limits the number of items stored to the specified capacity. When at capacity, the oldest items are removed in LRU to make root for new items. Putting and getting items maintains LRU order.

This is useful for implementing an LRU-cache on top of a datastore to maintain limited storage size, or to have an LRU-cache for values that may be too large to store in memory.

Note that while the keys and values are persisted in the datastore, the LRU-ordered list of keys is kept only in memory. Keeping the keys in memory only was done for performance so as not to maintain a linked list in the datastore.  This has two consequences:
- LRU order not maintained across restart
- Cannot have arbitrarily large LRU size

Reviewers, please evaluate whether the above is preferable, or if the LRU-ordered list of keys also needs to be persisted.