### PR TITLE
feat: return error from txn.Discard()

### DIFF
--- a/datastore.go
+++ b/datastore.go
@@ -173,7 +173,7 @@ type Txn interface {
 	// them to the underlying Datastore. Any calls made to Discard after Commit
 	// has been successfully called will have no effect on the transaction and
 	// state of the Datastore, making it safe to defer.
-	Discard(ctx context.Context)
+	Discard(ctx context.Context) error
 }
 
 // TxnDatastore is an interface that should be implemented by datastores that

--- a/null_ds.go
+++ b/null_ds.go
@@ -117,4 +117,6 @@ func (t *nullTxn) Commit(ctx context.Context) error {
 	return nil
 }
 
-func (t *nullTxn) Discard(ctx context.Context) {}
+func (t *nullTxn) Discard(ctx context.Context) error {
+	return nil
+}


### PR DESCRIPTION
To properly discard a transaction usually requires some external call
to the backing DB, which can fail. Currently implementations just
swallow any errors when discarding transactions, but this should be
surfaced to the application so that it can decide the appropriate
action (at the very least, log the error).

This is of course a breaking change and both datastore impls and
consumers will need to be updated.