### PR TITLE
chore: update upload-artifact action to v4

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -19,7 +19,7 @@ jobs:
         dry-run: false
         language: go
     - name: Upload Crash
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts


### PR DESCRIPTION
v3 is no longer supported as per https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/