### PR TITLE
Results.Close should return error

### DIFF
--- a/keytransform/keytransform.go
+++ b/keytransform/keytransform.go
@@ -94,8 +94,8 @@ func (d *Datastore) Query(ctx context.Context, q dsq.Query) (dsq.Results, error)
 			}
 			return r, true
 		},
-		Close: func() {
-			cqr.Close()
+		Close: func() error {
+			return cqr.Close()
 		},
 	})
 	return dsq.NaiveQueryApply(nq, qr), nil

--- a/mount/mount.go
+++ b/mount/mount.go
@@ -140,11 +140,12 @@ func (h *querySet) Pop() interface{} {
 	return last
 }
 
-func (h *querySet) close() {
+func (h *querySet) close() error {
 	for _, qr := range h.heads {
 		qr.results.Close()
 	}
 	h.heads = nil
+	return nil
 }
 
 func (h *querySet) addResults(mount ds.Key, results query.Results) {

--- a/query/query_impl.go
+++ b/query/query_impl.go
@@ -18,8 +18,8 @@ func NaiveFilter(qr Results, filter Filter) Results {
 				}
 			}
 		},
-		Close: func() {
-			qr.Close()
+		Close: func() error {
+			return qr.Close()
 		},
 	})
 }
@@ -43,12 +43,12 @@ func NaiveLimit(qr Results, limit int) Results {
 			limit--
 			return qr.NextSync()
 		},
-		Close: func() {
+		Close: func() error {
 			if closed {
-				return
+				return nil
 			}
 			closed = true
-			qr.Close()
+			return qr.Close()
 		},
 	})
 }
@@ -65,8 +65,8 @@ func NaiveOffset(qr Results, offset int) Results {
 			}
 			return qr.NextSync()
 		},
-		Close: func() {
-			qr.Close()
+		Close: func() error {
+			return qr.Close()
 		},
 	})
 }

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -200,7 +200,7 @@ func TestResultsFromIteratorNoClose(t *testing.T) {
 	testResultsFromIterator(t, getKeysViaChan, nil)
 }
 
-func testResultsFromIterator(t *testing.T, getKeys func(rs Results) []string, close func()) {
+func testResultsFromIterator(t *testing.T, getKeys func(rs Results) []string, close func() error) {
 	i := 0
 	results := ResultsFromIterator(Query{}, Iterator{
 		Next: func() (Result, bool) {
@@ -221,8 +221,9 @@ func testResultsFromIterator(t *testing.T, getKeys func(rs Results) []string, cl
 
 func testResultsFromIteratorWClose(t *testing.T, getKeys func(rs Results) []string) {
 	closeCalled := 0
-	testResultsFromIterator(t, getKeys, func() {
+	testResultsFromIterator(t, getKeys, func() error {
 		closeCalled++
+		return nil
 	})
 	if closeCalled != 1 {
 		t.Errorf("close called %d times, expect it to be called just once", closeCalled)


### PR DESCRIPTION
Results.Close should always return error. Even if it is not currently used for anything, having the ability to return error allows for higher level functionality to handle error conditions that may be important for future code. This was removed in v0.8.0, as it did not serve a functional purpose and was almost entirely unused/ignored.

The only ipfs/go-da-xxx modules affected are go-ds-leveldb, go-ds-sql, and go-ds-s3