### PR TITLE
feat: query iterator

### DIFF
--- a/datastore.go
+++ b/datastore.go
@@ -124,6 +124,10 @@ func QueryIter(ctx context.Context, ds Read, q query.Query) iter.Seq2[query.Entr
 		defer results.Close()
 
 		for result := range results.Next() {
+			if ctx.Err() != nil {
+				yield(query.Entry{}, ctx.Err())
+				return
+			}
 			if result.Error != nil {
 				yield(query.Entry{}, result.Error)
 				return

--- a/test/basic_tests.go
+++ b/test/basic_tests.go
@@ -405,6 +405,7 @@ func randValue() []byte {
 
 func subtestQuery(t *testing.T, ds dstore.Datastore, q dsq.Query, count int) {
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	var input []dsq.Entry
 	for i := 0; i < count; i++ {


### PR DESCRIPTION
Add a `QueryIter` function that returns a go iterator that allows ranging over query results. The range yields two values, a result `Entry` and an `error`. If an error is returned then iteration stops.

The `QueryIterator` function is a convenience that helps ensure query results are closed after use and that errors are checked.

Example:
```go
qry := query.Query{
	Prefix: keyPrefix,
}
var foundVal []byte
for ent, err := range QueryIter(dstore, qry) {
	if err != nil {
		return err
	}
	if ent.Key == lookingFor {
		foundVal = ent.Val
		break
	}
}
```