### PR TITLE
Test that a second batch commit does not error

### DIFF
--- a/test/test_util.go
+++ b/test/test_util.go
@@ -51,6 +51,12 @@ func RunBatchTest(t *testing.T, ds dstore.Batching) {
 		t.Fatal(err)
 	}
 
+	// seecond commit should do nothing, but should not cause error
+	err = batch.Commit(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	for i, k := range keys {
 		blk, err := ds.Get(ctx, k)
 		if err != nil {


### PR DESCRIPTION
This check would have caught an error that prevented reuse of a batch in one datastore.