### PR TITLE
Revert "Test that a second batch commit does not error"

### DIFF
--- a/test/test_util.go
+++ b/test/test_util.go
@@ -51,12 +51,6 @@ func RunBatchTest(t *testing.T, ds dstore.Batching) {
 		t.Fatal(err)
 	}
 
-	// seecond commit should do nothing, but should not cause error
-	err = batch.Commit(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	for i, k := range keys {
 		blk, err := ds.Get(ctx, k)
 		if err != nil {


### PR DESCRIPTION
Reverts ipfs/go-datastore#256

This change needs to be reverted because a Batch should not be reused as it is not guaranteed to be reusable with all datastores.