### PR TITLE
test suite: use a non-cancelled context to delete all keys

### DIFF
--- a/test/basic_tests.go
+++ b/test/basic_tests.go
@@ -565,6 +565,8 @@ func subtestQuery(t *testing.T, ds dstore.Datastore, q dsq.Query, count int) {
 		}
 	}
 
+	// use a new context, since previous was cancelled.
+	ctx = context.Background()
 	t.Log("deleting all keys")
 	for _, e := range input {
 		if err := ds.Delete(ctx, dstore.RawKey(e.Key)); err != nil {


### PR DESCRIPTION
The test suite will fail if the Delete operation cares about the context, because the used context has been cancelled. This was surfaced in:

https://github.com/ipfs/go-ds-s3/pull/306

because go-ds-s3 cares about the context.